### PR TITLE
Small change to rootlogon.C, to allow ROOT 6 compatibility.

### DIFF
--- a/scripts/rootlogon.C
+++ b/scripts/rootlogon.C
@@ -7,7 +7,7 @@
 //
 ///////////////////////////////////////////////////////////////////////////
 
-bool load(TString &dir, TString &libfilename)
+bool load(TString &dir, const TString &libfilename)
 {
     cout << "\033[33m\033[1m" << "Loading " << dir << libfilename << " \033[0m" << flush;
 


### PR DESCRIPTION
Dear and respected @javierrico 

Playing around with this wonderful package, together with @chiaragiuri, we realized that the rootlogon.C script gives some error when using ROOT 6. The compilation process works smoothly, but when running executing root, the following error appears:

```c++
In file included from input_line_10:1:
$GLIKESYS/scripts/rootlogon.C:43:10: error: no matching function for call to 'load'
    if (!load(libdir,libfilename)) return;
         ^~~~
$GLIKESYS/scripts/rootlogon.C:10:6: note: candidate function not viable: 2nd argument ('const TString') would lose const qualifier
bool load(TString &dir, TString &libfilename)
```

After testing the same procedure with ROOT 5.34.32, it worked properly, so it was definitely an issue with ROOT 6 within the rootlogon.C.

After doing the small change you can see in this pull request, the problem was solved when using ROOT 6 (checked also that ROOT 5 still works).

The problem can also be solved by removing the `const` within line 30.

You are welcome! :) 