### PR TITLE
Brane tension

### DIFF
--- a/scripts/computeCLBands.C
+++ b/scripts/computeCLBands.C
@@ -33,6 +33,7 @@
 #include <iostream>
 #include <iomanip>
 #include <fstream>
+#include <sstream>
 #include <vector>
 
 #include "TPRegexp.h"
@@ -40,6 +41,7 @@
 #include "TH1.h"
 #include "TF1.h"
 #include "TString.h"
+#include "TObjString.h"
 #include "TCanvas.h"
 #include "TLatex.h"
 #include "TFile.h"
@@ -337,6 +339,7 @@ void computeCLBands(TString configFileName="$GLIKESYS/rcfiles/jointLklDM.rc",Int
       Double_t braneTensionVal[nmass];
       for(Int_t imass=shift;imass<nmass;imass++)
         {
+          Float_t mdm = massval[imass];
           // release the memory of channelval and brval
           delete [] channelval;
           delete [] brval;
@@ -345,32 +348,32 @@ void computeCLBands(TString configFileName="$GLIKESYS/rcfiles/jointLklDM.rc",Int
           channelval = new TString[nChannels];
           brval = new Double_t[nChannels];
           // call the function that computes the branching ratios and save them in channelval and brval
-          compute_branonBR(massval[imass],nChannels,channelval,brval,braneTensionVal[imass]);
+          compute_branonBR(mdm,nChannels,channelval,brval,braneTensionVal[imass]);
         }
 
       cout << "Double_t bt0sigma_"+channel+"[nmass]  = {";
       for(Int_t imass=shift;imass<nmass;imass++)
-        cout << braneTensionVal[imass]/(TMath::Power(sv0sigma[imass], 1./8.)) << (imass<nmass-1? "," : "");
+        cout << 0.001*braneTensionVal[imass]/(TMath::Power(sv0sigma[imass], 1./8.)) << (imass<nmass-1? "," : "");
       cout << "};" << endl;
 
       cout << "Double_t bt1sigmaL_"+channel+"[nmass] = {";
       for(Int_t imass=shift;imass<nmass;imass++)
-        cout << braneTensionVal[imass]/(TMath::Power(sv1sigmaL[imass], 1./8.)) << (imass<nmass-1? "," : "");
+        cout << 0.001*braneTensionVal[imass]/(TMath::Power(sv1sigmaL[imass], 1./8.)) << (imass<nmass-1? "," : "");
       cout << "};" << endl;
 
       cout << "Double_t bt2sigmaL_"+channel+"[nmass] = {";
       for(Int_t imass=shift;imass<nmass;imass++)
-        cout << braneTensionVal[imass]/(TMath::Power(sv2sigmaL[imass], 1./8.)) << (imass<nmass-1? "," : "");
+        cout << 0.001*braneTensionVal[imass]/(TMath::Power(sv2sigmaL[imass], 1./8.)) << (imass<nmass-1? "," : "");
       cout << "};" << endl;
 
       cout << "Double_t bt1sigmaR_"+channel+"[nmass] = {";
       for(Int_t imass=shift;imass<nmass;imass++)
-        cout << braneTensionVal[imass]/(TMath::Power(sv1sigmaR[imass], 1./8.)) << (imass<nmass-1? "," : "");
+        cout << 0.001*braneTensionVal[imass]/(TMath::Power(sv1sigmaR[imass], 1./8.)) << (imass<nmass-1? "," : "");
       cout << "};" << endl;
 
       cout << "Double_t bt2sigmaR_"+channel+"[nmass] = {";
       for(Int_t imass=shift;imass<nmass;imass++)
-        cout << braneTensionVal[imass]/(TMath::Power(sv2sigmaR[imass], 1./8.)) << (imass<nmass-1? "," : "");
+        cout << 0.001*braneTensionVal[imass]/(TMath::Power(sv2sigmaR[imass], 1./8.)) << (imass<nmass-1? "," : "");
       cout << "};" << endl;
 
     }
@@ -640,11 +643,11 @@ void compute_branonBR(Float_t &mass, Int_t &nChannels, TString *channelval, Doub
         if(mass >= particle_mass[iChannel])
           {
             if (dirac_fermions.Contains(particle_type[iChannel]))
-              ann_crosssection[iChannel] = (mass*mass * particle_mass[iChannel]*particle_mass[iChannel])/(16. * TMath::Pi()*TMath::Pi()) * (mass*mass - particle_mass[iChannel]*particle_mass[iChannel]) * $
+              ann_crosssection[iChannel] = (mass*mass * particle_mass[iChannel]*particle_mass[iChannel])/(16. * TMath::Pi()*TMath::Pi()) * (mass*mass - particle_mass[iChannel]*particle_mass[iChannel]) * TMath::Sqrt(1-((particle_mass[iChannel]*particle_mass[iChannel])/(mass*mass)));
             else if (gauge_bosons.Contains(particle_type[iChannel]))
-              ann_crosssection[iChannel] = (mass*mass)/(64. * TMath::Pi()*TMath::Pi()) * (4. * TMath::Power(mass,4) - 4. * mass*mass * particle_mass[iChannel]*particle_mass[iChannel] + 3. * TMath::Power($
+              ann_crosssection[iChannel] = (mass*mass)/(64. * TMath::Pi()*TMath::Pi()) * (4. * TMath::Power(mass,4) - 4. * mass*mass * particle_mass[iChannel]*particle_mass[iChannel] + 3. * TMath::Power(particle_mass[iChannel],4)) * TMath::Sqrt(1-((particle_mass[iChannel]*particle_mass[iChannel])/(mass*mass)));
             else if (scalar_bosons.Contains(particle_type[iChannel]))
-              ann_crosssection[iChannel] = (mass*mass)/(32. * TMath::Pi()*TMath::Pi()) * TMath::Power((2.* mass*mass + particle_mass[iChannel]*particle_mass[iChannel]),2) * TMath::Sqrt(1-((particle_mass[$
+              ann_crosssection[iChannel] = (mass*mass)/(32. * TMath::Pi()*TMath::Pi()) * TMath::Power((2.* mass*mass + particle_mass[iChannel]*particle_mass[iChannel]),2) * TMath::Sqrt(1-((particle_mass[iChannel]*particle_mass[iChannel])/(mass*mass)));
             // WW with a factor 2 (because the W is complex)
             if(!particle_type[iChannel].CompareTo("WW",TString::kIgnoreCase)) ann_crosssection[iChannel] *= 2.;
             // hh with a factor 1/2 (because the Higgs is real)

--- a/scripts/computeCLBands.C
+++ b/scripts/computeCLBands.C
@@ -356,12 +356,18 @@ void computeCLBands(TString configFileName="$GLIKESYS/rcfiles/jointLklDM.rc",Int
         }
 
       // To translate the sigmav values from [cm^3 s^-1] to [GeV^-2], the sigmav limits have to be divided by
-      // h_bar^2 c^3 = (6.58*10^-25 [GeV s])^2 * (3.0*10^10 [cm s^-1])^2 = 1.17*10^-17 [GeV^2 cm^3 s^-1].
-      // The 0.001 factor is translating the brane tension limit from GeV to TeV.
+      // h_bar^2 c^3 = (6.582119569^-25 [GeV s])^2 * (299792458x10^2 [cm s^-1])^3 = 1.167329990*10^-17 [GeV^2 cm^3 s^-1]
+      // with following the values provided by the Particle Data Group in http://pdg.lbl.gov/2019/reviews/rpp2018-rev-phys-constants.pdf
+      // h_bar = 6.582119569*10^-22 [MeV s] = 6.58211956910*^-25 [GeV s] and c = 299792458.0 [m s^−1] = 299792458.0*10^2 [cm s^−1].
+      // The final conversion formula also contains:
+      // - a factor (0.001) to translate the brane tension limit from [GeV] to [TeV]
+      // - a power 1/8 to relate sigma to f (see equation 7 of https://arxiv.org/abs/hep-ph/0302041)
+      Double_t unit_translation = 1.167329990*TMath::Power(10., -17.);
+
       cout << "Double_t bt0sigma[nmass]  = {";
       for(Int_t imass=shift;imass<nmass;imass++)
         {
-          bt0sigma[imass] = 0.001*TMath::Power((braneTensionVal[imass]*1.17*TMath::Power(10., -17.))/sv0sigma[imass], 1./8.);
+          bt0sigma[imass] = 0.001*TMath::Power((braneTensionVal[imass]*unit_translation)/sv0sigma[imass], 1./8.);
           cout << bt0sigma[imass] << (imass<nmass-1? "," : "");
         }
       cout << "};" << endl;
@@ -369,7 +375,7 @@ void computeCLBands(TString configFileName="$GLIKESYS/rcfiles/jointLklDM.rc",Int
       cout << "Double_t bt1sigmaL[nmass] = {";
       for(Int_t imass=shift;imass<nmass;imass++)
         {
-          bt1sigmaL[imass] = 0.001*TMath::Power((braneTensionVal[imass]*1.17*TMath::Power(10., -17.))/sv1sigmaL[imass], 1./8.);
+          bt1sigmaL[imass] = 0.001*TMath::Power((braneTensionVal[imass]*unit_translation)/sv1sigmaL[imass], 1./8.);
           cout << bt1sigmaL[imass] << (imass<nmass-1? "," : "");
         }
       cout << "};" << endl;
@@ -377,7 +383,7 @@ void computeCLBands(TString configFileName="$GLIKESYS/rcfiles/jointLklDM.rc",Int
       cout << "Double_t bt2sigmaL[nmass] = {";
       for(Int_t imass=shift;imass<nmass;imass++)
         {
-          bt2sigmaL[imass] = 0.001*TMath::Power((braneTensionVal[imass]*1.17*TMath::Power(10., -17.))/sv2sigmaL[imass], 1./8.);
+          bt2sigmaL[imass] = 0.001*TMath::Power((braneTensionVal[imass]*unit_translation)/sv2sigmaL[imass], 1./8.);
           cout << bt2sigmaL[imass] << (imass<nmass-1? "," : "");
         }
       cout << "};" << endl;
@@ -385,7 +391,7 @@ void computeCLBands(TString configFileName="$GLIKESYS/rcfiles/jointLklDM.rc",Int
       cout << "Double_t bt1sigmaR[nmass] = {";
       for(Int_t imass=shift;imass<nmass;imass++)
         {
-          bt1sigmaR[imass] = 0.001*TMath::Power((braneTensionVal[imass]*1.17*TMath::Power(10., -17.))/sv1sigmaR[imass], 1./8.);
+          bt1sigmaR[imass] = 0.001*TMath::Power((braneTensionVal[imass]*unit_translation)/sv1sigmaR[imass], 1./8.);
           cout << bt1sigmaR[imass] << (imass<nmass-1? "," : "");
         }
       cout << "};" << endl;
@@ -393,7 +399,7 @@ void computeCLBands(TString configFileName="$GLIKESYS/rcfiles/jointLklDM.rc",Int
       cout << "Double_t bt2sigmaR[nmass] = {";
       for(Int_t imass=shift;imass<nmass;imass++)
         {
-          bt2sigmaR[imass] = 0.001*TMath::Power((braneTensionVal[imass]*1.17*TMath::Power(10., -17.))/sv2sigmaR[imass], 1./8.);
+          bt2sigmaR[imass] = 0.001*TMath::Power((braneTensionVal[imass]*unit_translation)/sv2sigmaR[imass], 1./8.);
           cout << bt2sigmaR[imass] << (imass<nmass-1? "," : "");
         }
       cout << "};" << endl;

--- a/scripts/computeCLBands.C
+++ b/scripts/computeCLBands.C
@@ -353,27 +353,27 @@ void computeCLBands(TString configFileName="$GLIKESYS/rcfiles/jointLklDM.rc",Int
 
       cout << "Double_t bt0sigma_"+channel+"[nmass]  = {";
       for(Int_t imass=shift;imass<nmass;imass++)
-        cout << 0.001*braneTensionVal[imass]/(TMath::Power(sv0sigma[imass], 1./8.)) << (imass<nmass-1? "," : "");
+        cout << 0.001*TMath::Power((braneTensionVal[imass]*1.167*TMath::Power(10., -17.))/sv0sigma[imass], 1./8.) << (imass<nmass-1? "," : "");
       cout << "};" << endl;
 
       cout << "Double_t bt1sigmaL_"+channel+"[nmass] = {";
       for(Int_t imass=shift;imass<nmass;imass++)
-        cout << 0.001*braneTensionVal[imass]/(TMath::Power(sv1sigmaL[imass], 1./8.)) << (imass<nmass-1? "," : "");
+        cout << 0.001*TMath::Power((braneTensionVal[imass]*1.167*TMath::Power(10., -17.))/sv1sigmaL[imass], 1./8.) << (imass<nmass-1? "," : "");
       cout << "};" << endl;
 
       cout << "Double_t bt2sigmaL_"+channel+"[nmass] = {";
       for(Int_t imass=shift;imass<nmass;imass++)
-        cout << 0.001*braneTensionVal[imass]/(TMath::Power(sv2sigmaL[imass], 1./8.)) << (imass<nmass-1? "," : "");
+        cout << 0.001*TMath::Power((braneTensionVal[imass]*1.167*TMath::Power(10., -17.))/sv2sigmaL[imass], 1./8.) << (imass<nmass-1? "," : "");
       cout << "};" << endl;
 
       cout << "Double_t bt1sigmaR_"+channel+"[nmass] = {";
       for(Int_t imass=shift;imass<nmass;imass++)
-        cout << 0.001*braneTensionVal[imass]/(TMath::Power(sv1sigmaR[imass], 1./8.)) << (imass<nmass-1? "," : "");
+        cout << 0.001*TMath::Power((braneTensionVal[imass]*1.167*TMath::Power(10., -17.))/sv1sigmaR[imass], 1./8.) << (imass<nmass-1? "," : "");
       cout << "};" << endl;
 
       cout << "Double_t bt2sigmaR_"+channel+"[nmass] = {";
       for(Int_t imass=shift;imass<nmass;imass++)
-        cout << 0.001*braneTensionVal[imass]/(TMath::Power(sv2sigmaR[imass], 1./8.)) << (imass<nmass-1? "," : "");
+        cout << 0.001*TMath::Power((braneTensionVal[imass]*1.167*TMath::Power(10., -17.))/sv2sigmaR[imass], 1./8.) << (imass<nmass-1? "," : "");
       cout << "};" << endl;
 
     }
@@ -666,5 +666,5 @@ void compute_branonBR(Float_t &mass, Int_t &nChannels, TString *channelval, Doub
         channelval[iChannel] = particle_type[iChannel];
       }
     // Computation of the translation factor for the tension of the brane
-    translation_factor = TMath::Power(total_ann_crosssection, 1./8.);
+    translation_factor = total_ann_crosssection;
   }

--- a/scripts/computeCLBands.C
+++ b/scripts/computeCLBands.C
@@ -331,8 +331,12 @@ void computeCLBands(TString configFileName="$GLIKESYS/rcfiles/jointLklDM.rc",Int
     cout << sv2sigmaR[imass] << (imass<nmass-1? "," : "");
   cout << "};" << endl;
 
-  
-  // compute the branching ratios for the branon model for each DM mass
+  // compute the branon translation factor for each DM mass for branon
+  Double_t bt0sigma[nmass];
+  Double_t bt1sigmaL[nmass];
+  Double_t bt2sigmaL[nmass];
+  Double_t bt1sigmaR[nmass];
+  Double_t bt2sigmaR[nmass];
   if(!channel.CompareTo("branon",TString::kIgnoreCase))
     {
       // initialize the array of translation factors for the brane tension limits
@@ -351,32 +355,50 @@ void computeCLBands(TString configFileName="$GLIKESYS/rcfiles/jointLklDM.rc",Int
           compute_branonBR(mdm,nChannels,channelval,brval,braneTensionVal[imass]);
         }
 
-      cout << "Double_t bt0sigma_"+channel+"[nmass]  = {";
+      // To translate the sigmav values from [cm^3 s^-1] to [GeV^-2], the sigmav limits have to be divided by
+      // h_bar^2 c^3 = (6.58*10^-25 [GeV s])^2 * (3.0*10^10 [cm s^-1])^2 = 1.17*10^-17 [GeV^2 cm^3 s^-1].
+      // The 0.001 factor is translating the brane tension limit from GeV to TeV.
+      cout << "Double_t bt0sigma[nmass]  = {";
       for(Int_t imass=shift;imass<nmass;imass++)
-        cout << 0.001*TMath::Power((braneTensionVal[imass]*1.167*TMath::Power(10., -17.))/sv0sigma[imass], 1./8.) << (imass<nmass-1? "," : "");
+        {
+          bt0sigma[imass] = 0.001*TMath::Power((braneTensionVal[imass]*1.17*TMath::Power(10., -17.))/sv0sigma[imass], 1./8.);
+          cout << bt0sigma[imass] << (imass<nmass-1? "," : "");
+        }
       cout << "};" << endl;
 
-      cout << "Double_t bt1sigmaL_"+channel+"[nmass] = {";
+      cout << "Double_t bt1sigmaL[nmass] = {";
       for(Int_t imass=shift;imass<nmass;imass++)
-        cout << 0.001*TMath::Power((braneTensionVal[imass]*1.167*TMath::Power(10., -17.))/sv1sigmaL[imass], 1./8.) << (imass<nmass-1? "," : "");
+        {
+          bt1sigmaL[imass] = 0.001*TMath::Power((braneTensionVal[imass]*1.17*TMath::Power(10., -17.))/sv1sigmaL[imass], 1./8.);
+          cout << bt1sigmaL[imass] << (imass<nmass-1? "," : "");
+        }
       cout << "};" << endl;
 
-      cout << "Double_t bt2sigmaL_"+channel+"[nmass] = {";
+      cout << "Double_t bt2sigmaL[nmass] = {";
       for(Int_t imass=shift;imass<nmass;imass++)
-        cout << 0.001*TMath::Power((braneTensionVal[imass]*1.167*TMath::Power(10., -17.))/sv2sigmaL[imass], 1./8.) << (imass<nmass-1? "," : "");
+        {
+          bt2sigmaL[imass] = 0.001*TMath::Power((braneTensionVal[imass]*1.17*TMath::Power(10., -17.))/sv2sigmaL[imass], 1./8.);
+          cout << bt2sigmaL[imass] << (imass<nmass-1? "," : "");
+        }
       cout << "};" << endl;
 
-      cout << "Double_t bt1sigmaR_"+channel+"[nmass] = {";
+      cout << "Double_t bt1sigmaR[nmass] = {";
       for(Int_t imass=shift;imass<nmass;imass++)
-        cout << 0.001*TMath::Power((braneTensionVal[imass]*1.167*TMath::Power(10., -17.))/sv1sigmaR[imass], 1./8.) << (imass<nmass-1? "," : "");
+        {
+          bt1sigmaR[imass] = 0.001*TMath::Power((braneTensionVal[imass]*1.17*TMath::Power(10., -17.))/sv1sigmaR[imass], 1./8.);
+          cout << bt1sigmaR[imass] << (imass<nmass-1? "," : "");
+        }
       cout << "};" << endl;
 
-      cout << "Double_t bt2sigmaR_"+channel+"[nmass] = {";
+      cout << "Double_t bt2sigmaR[nmass] = {";
       for(Int_t imass=shift;imass<nmass;imass++)
-        cout << 0.001*TMath::Power((braneTensionVal[imass]*1.167*TMath::Power(10., -17.))/sv2sigmaR[imass], 1./8.) << (imass<nmass-1? "," : "");
+        {
+          bt2sigmaR[imass] = 0.001*TMath::Power((braneTensionVal[imass]*1.17*TMath::Power(10., -17.))/sv2sigmaR[imass], 1./8.);
+          cout << bt2sigmaR[imass] << (imass<nmass-1? "," : "");
+        }
       cout << "};" << endl;
-
     }
+
   // Save results as graphs in a root file
   TString outputFileName = resultsPath+"root/"+label+"_1and2sigmasBands.root";
   TFile*  outputFile     = new TFile(outputFileName,"RECREATE");
@@ -399,6 +421,38 @@ void computeCLBands(TString configFileName="$GLIKESYS/rcfiles/jointLklDM.rc",Int
 
   cout << endl << "Bands saved in file: " << outputFileName << endl;
   delete outputFile;
+
+  // Save results as graphs in a root file for branon
+  TGraph* gbt0sigma  = NULL;
+  TGraph* gbt1sigmaL = NULL;
+  TGraph* gbt1sigmaR = NULL;
+  TGraph* gbt2sigmaL = NULL;
+  TGraph* gbt2sigmaR = NULL;
+  if(!channel.CompareTo("branon",TString::kIgnoreCase))
+    {
+      TString btoutputFileName = resultsPath+"root/"+label+"_branetension_1and2sigmasBands.root";
+      TFile*  btoutputFile     = new TFile(btoutputFileName,"RECREATE");
+
+      gbt0sigma  = new TGraph(nmass-shift,massval+shift,bt0sigma+shift);
+      gbt1sigmaL = new TGraph(nmass-shift,massval+shift,bt1sigmaL+shift);
+      gbt1sigmaR = new TGraph(nmass-shift,massval+shift,bt1sigmaR+shift);
+      gbt2sigmaL = new TGraph(nmass-shift,massval+shift,bt2sigmaL+shift);
+      gbt2sigmaR = new TGraph(nmass-shift,massval+shift,bt2sigmaR+shift);
+      gbt0sigma->SetName("gbt0sigma");
+      gbt1sigmaL->SetName("gbt1sigmaL");
+      gbt1sigmaR->SetName("gbt1sigmaR");
+      gbt2sigmaL->SetName("gbt2sigmaL");
+      gbt2sigmaR->SetName("gbt2sigmaR");
+      gbt0sigma->Write();
+      gbt1sigmaL->Write();
+      gbt1sigmaR->Write();
+      gbt2sigmaL->Write();
+      gbt2sigmaR->Write();
+
+      cout << "Bands saved in file: " << btoutputFileName << endl;
+      delete btoutputFile;
+    }
+
 
   // PLOTS
   if(makePlots)
@@ -509,6 +563,92 @@ void computeCLBands(TString configFileName="$GLIKESYS/rcfiles/jointLklDM.rc",Int
 
       limcanvas->Print(resultsPath+"root/"+label+"_bands.root");
       limcanvas->Print(resultsPath+"pdf/"+label+"_bands.pdf");
+
+      if(!channel.CompareTo("branon",TString::kIgnoreCase))
+        {
+          // bands
+          Int_t npnts = gbt0sigma->GetN();
+          TGraph* btband1sigma = new TGraph(2*npnts+1);
+          TGraph* btband2sigma = new TGraph(2*npnts+1);
+
+          for(Int_t imass=0;imass<npnts;imass++)
+            {
+              btband1sigma->SetPoint(imass,      gbt1sigmaL->GetX()[imass],gbt1sigmaL->GetY()[imass]);
+              btband1sigma->SetPoint(npnts+imass,gbt1sigmaR->GetX()[npnts-imass-1],gbt1sigmaR->GetY()[npnts-imass-1]);
+              btband2sigma->SetPoint(imass,      gbt2sigmaL->GetX()[imass],gbt2sigmaL->GetY()[imass]);
+              btband2sigma->SetPoint(npnts+imass,gbt2sigmaR->GetX()[npnts-imass-1],gbt2sigmaR->GetY()[npnts-imass-1]);
+            }
+          btband1sigma->SetPoint(2*npnts,gbt1sigmaL->GetX()[0],gbt1sigmaL->GetY()[0]);
+          btband2sigma->SetPoint(2*npnts,gbt2sigmaL->GetX()[0],gbt2sigmaL->GetY()[0]);
+
+          // result
+          TFile* btf = TFile::Open(dataPath+label+"_Data_branetension_limits.root", "READ");
+          TCanvas* btlim = (TCanvas*)btf->Get("branoncanvas");
+          TGraph* grbtlim = (TGraph*)btlim->GetPrimitive("grbtlim");
+
+          grbtlim->SetName("grbtlim");
+          grbtlim->SetLineColor(kBlack);
+          grbtlim->SetLineWidth(2);
+
+          btband1sigma->SetFillColorAlpha(3,0.35);
+          btband2sigma->SetFillColorAlpha(5,0.35);
+
+          gbt0sigma->SetLineColor(4);
+          gbt0sigma->SetLineStyle(2);
+          gbt0sigma->SetLineWidth(1);
+
+          // canvas
+          TCanvas* branoncanvas = new TCanvas("branoncanvas","1 and 2 sigma bands",1000,800);
+          branoncanvas->cd();
+
+          TH1I *btdummylim = new TH1I("btdummylim","",1,massval[0],massval[nmass-1]);
+          btdummylim->SetStats(0);
+          btdummylim->SetMinimum(1e-1);
+          btdummylim->SetMaximum(1e2);
+          btdummylim->SetXTitle("m_{DM} [GeV]");
+          btdummylim->SetYTitle(Form("f [TeV]"));
+          btdummylim->DrawCopy();
+          gPad->SetLogx();
+          gPad->SetLogy();
+          gPad->SetGrid();
+
+          btband2sigma->Draw("f");
+          btband1sigma->Draw("f");
+          gbt0sigma->Draw("c");
+          grbtlim->Draw("c");
+
+          // thermal relic density taken from Steigman G., Dasgupta B, and Beacom J. F., 
+          // Precise relic WIMP abundance and its impact onsearches for dark matter annihilation, 
+          // Phys.Rev. D86(2012) 023506, [arXiv:1204.3622]. The thermal relic cross section was 
+          // translated to the brane tension space using the formulas above.
+          const Int_t nThermalRelicBt = 22;
+          Double_t thermalRelicMass[nThermalRelicBt] = {1.00e-01, 1.78e-01, 3.16e-01, 5.62e-01, 1.00e+00, 1.78e+00, 3.16e+00, 5.62e+00, 1.00e+01, 1.78e+01, 3.16e+01, 5.62e+01, 1.00e+02, 1.78e+02, 3.16e+02, 5.62e+02, 1.00e+03, 1.78e+03,3.16e+03, 5.62e+03, 1.00e+04, 1.00e+05};
+          Double_t thermalRelicBt[nThermalRelicBt] = {0.00028197, 0.00131177, 0.00184612, 0.00250686, 0.00338571, 0.00742158, 0.0124374, 0.0199107, 0.0291449, 0.0400859, 0.054027, 0.0721836, 0.208693, 0.367468, 0.578445, 0.892658, 1.37518, 2.11902, 3.25889, 5.01881, 7.69107, 43.25};
+          TGraph *btrelicDensity = new TGraph(nThermalRelicBt, thermalRelicMass, thermalRelicBt);
+          btrelicDensity->SetTitle("Thermal relic cross section");
+          btrelicDensity->SetLineColor(kRed);
+          btrelicDensity->SetLineWidth(3);
+          btrelicDensity->SetLineStyle(5);
+          btrelicDensity->SetMarkerColor(kRed);
+          btrelicDensity->Draw("same");
+
+          // legend
+          TLegend* btlimleg;
+          btlimleg = new TLegend(0.2, 0.7, 0.45, 0.85);
+          btlimleg->SetTextSize(0.032);
+          btlimleg->SetMargin(0.40);
+          btlimleg->SetBorderSize(0);
+
+          if(grbtlim)    btlimleg->AddEntry(grbtlim,"Limit","l");
+          if(gbt0sigma)  btlimleg->AddEntry(gbt0sigma,"H_{0} median","l");
+          if(btband1sigma) btlimleg->AddEntry(btband1sigma,"H_{0} 68% containment","f");
+          if(btband2sigma) btlimleg->AddEntry(btband2sigma,"H_{0} 95% containment","f");
+          btlimleg->AddEntry(btrelicDensity,"Thermal relic cross section","l");
+          btlimleg->Draw();
+
+          branoncanvas->Print(resultsPath+"root/"+label+"_branetension_bands.root");
+          branoncanvas->Print(resultsPath+"pdf/"+label+"_branetension_bands.pdf");
+        }
     }
 }
 

--- a/scripts/jointLklDM.C
+++ b/scripts/jointLklDM.C
@@ -919,7 +919,7 @@ void jointLklDM(TString configFileName="$GLIKESYS/rcfiles/jointLklDM.rc",Int_t s
     {
       cout << "Double_t braneTensionLimit[nmass]  = {";
       for(Int_t imass=0;imass<nmass;imass++)
-        cout << braneTensionVal[imass]/(TMath::Power(svLimVal[imass], 1./8.)) << (imass<nmass-1? "," : "");
+        cout << 0.001*braneTensionVal[imass]/(TMath::Power(svLimVal[imass], 1./8.)) << (imass<nmass-1? "," : "");
       cout << "};" << endl;
     }
  

--- a/scripts/jointLklDM.C
+++ b/scripts/jointLklDM.C
@@ -919,7 +919,7 @@ void jointLklDM(TString configFileName="$GLIKESYS/rcfiles/jointLklDM.rc",Int_t s
     {
       cout << "Double_t braneTensionLimit[nmass]  = {";
       for(Int_t imass=0;imass<nmass;imass++)
-        cout << 0.001*braneTensionVal[imass]/(TMath::Power(svLimVal[imass], 1./8.)) << (imass<nmass-1? "," : "");
+        cout << 0.001*TMath::Power((braneTensionVal[imass]*1.167*TMath::Power(10., -17.))/svLimVal[imass], 1./8.) << (imass<nmass-1? "," : "");
       cout << "};" << endl;
     }
  
@@ -1173,5 +1173,5 @@ void compute_branonBR(Float_t &mass, Int_t &nChannels, TString *channelval, Doub
         channelval[iChannel] = particle_type[iChannel];
       }
     // Computation of the translation factor for the tension of the brane
-    translation_factor = TMath::Power(total_ann_crosssection, 1./8.);
+    translation_factor = total_ann_crosssection;
   }

--- a/scripts/jointLklDM.C
+++ b/scripts/jointLklDM.C
@@ -917,8 +917,14 @@ void jointLklDM(TString configFileName="$GLIKESYS/rcfiles/jointLklDM.rc",Int_t s
   cout << "};" << endl;
 
   // To translate the sigmav values from [cm^3 s^-1] to [GeV^-2], the sigmav limits have to be divided by
-  // h_bar^2 c^3 = (6.58*10^-25 [GeV s])^2 * (3.0*10^10 [cm s^-1])^2 = 1.17*10^-17 [GeV^2 cm^3 s^-1].
-  // The 0.001 factor is translating the brane tension limit from GeV to TeV.
+  // h_bar^2 c^3 = (6.582119569^-25 [GeV s])^2 * (299792458x10^2 [cm s^-1])^3 = 1.167329990*10^-17 [GeV^2 cm^3 s^-1]
+  // with following the values provided by the Particle Data Group in http://pdg.lbl.gov/2019/reviews/rpp2018-rev-phys-constants.pdf
+  // h_bar = 6.582119569*10^-22 [MeV s] = 6.58211956910*^-25 [GeV s] and c = 299792458.0 [m s^−1] = 299792458.0*10^2 [cm s^−1].
+  // The final conversion formula also contains:
+  // - a factor (0.001) to translate the brane tension limit from [GeV] to [TeV]
+  // - a power 1/8 to relate sigma to f (see equation 7 of https://arxiv.org/abs/hep-ph/0302041)
+  Double_t unit_translation = 1.167329990*TMath::Power(10., -17.);
+
   Double_t fLimVal[nmass];
   Double_t fSenVal[nmass];
   if(!channel.CompareTo("branon",TString::kIgnoreCase))
@@ -926,14 +932,14 @@ void jointLklDM(TString configFileName="$GLIKESYS/rcfiles/jointLklDM.rc",Int_t s
       cout << "Double_t branetension_limit[nmass]  = {";
       for(Int_t imass=0;imass<nmass;imass++)
         {
-          fLimVal[imass] = 0.001*TMath::Power((braneTensionVal[imass]*1.17*TMath::Power(10., -17.))/svLimVal[imass], 1./8.);
+          fLimVal[imass] = 0.001*TMath::Power((braneTensionVal[imass]*unit_translation)/svLimVal[imass], 1./8.);
           cout << fLimVal[imass] << (imass<nmass-1? "," : "");
         }
       cout << "};" << endl;
       cout << "Double_t branetension_snstvt[nmass]  = {";
       for(Int_t imass=0;imass<nmass;imass++)
         {
-          fSenVal[imass] = 0.001*TMath::Power((braneTensionVal[imass]*1.17*TMath::Power(10., -17.))/svSenVal[imass], 1./8.);
+          fSenVal[imass] = 0.001*TMath::Power((braneTensionVal[imass]*unit_translation)/svSenVal[imass], 1./8.);
           cout << fSenVal[imass] << (imass<nmass-1? "," : "");
         }
       cout << "};" << endl;
@@ -1037,8 +1043,8 @@ void jointLklDM(TString configFileName="$GLIKESYS/rcfiles/jointLklDM.rc",Int_t s
 
       TH1I *dummybtlim = new TH1I("dummybtlim",Form("f ULs vs mass"),1,massval[0],massval[nmass-1]);
       dummybtlim->SetStats(0);
-      dummybtlim->SetMinimum(0.001*TMath::Power((braneTensionVal[0]*1.17*TMath::Power(10., -17.))/plotmax, 1./8.));
-      dummybtlim->SetMaximum(0.001*TMath::Power((braneTensionVal[nmass-1]*1.17*TMath::Power(10., -17.))/plotmin, 1./8.));
+      dummybtlim->SetMinimum(0.001*TMath::Power((braneTensionVal[0]*unit_translation)/plotmax, 1./8.));
+      dummybtlim->SetMaximum(0.001*TMath::Power((braneTensionVal[nmass-1]*unit_translation)/plotmin, 1./8.));
       dummybtlim->SetXTitle("m_{DM} [GeV]");
       dummybtlim->SetYTitle("f [TeV]");
       dummybtlim->DrawCopy();

--- a/src/GloryDuckTables2019Lkl.cc
+++ b/src/GloryDuckTables2019Lkl.cc
@@ -240,9 +240,9 @@ Int_t GloryDuckTables2019Lkl::ReadGloryDuckInputData(TString filename)
         {
           if(TMath::Abs(field-fLogJ) > 1.e-6)
             {
-              cout << "GloryDuckTables2019Lkl::ReadGloryDuckInputData (" << GetName() << ") Warning: the logJ value stored in the file (" << field << ") doesn't match the one given as an input in the configuration file (" << fLogJ  << "). Therefore the likelihood values from this file will be scaled by 10^(" << fLogJ << "-" << field << ")=" << TMath::Power(10.,fLogJ-field) << " to match the intended logJ value from the configuration file." << endl;
+              cout << "GloryDuckTables2019Lkl::ReadGloryDuckInputData (" << GetName() << ") Warning: the logJ value stored in the file (" << field << ") doesn't match the one given as an input in the configuration file (" << fLogJ  << "). Therefore the likelihood values from this file will be scaled by 10^(" << field << "-" << fLogJ << ")=" << TMath::Power(10.,field-fLogJ) << " to match the intended logJ value from the configuration file." << endl;
               rescale_logJ = kTRUE;
-              scaling_logJ = TMath::Power(10.,fLogJ-field);
+              scaling_logJ = TMath::Power(10.,field-fLogJ);
             }
           read_logJ = kFALSE;
         }
@@ -265,6 +265,7 @@ Int_t GloryDuckTables2019Lkl::ReadGloryDuckInputData(TString filename)
   while(ff >> readingSigmav)
     {
       // store the <sv> values
+      if(rescale_logJ) readingSigmav *= scaling_logJ;
       sigmav.push_back(readingSigmav);
 
       // get rest of the line
@@ -277,7 +278,6 @@ Int_t GloryDuckTables2019Lkl::ReadGloryDuckInputData(TString filename)
       std::istringstream line(LklLine);
       while(line >> readingLkl)
         {
-          if(rescale_logJ) readingLkl *= scaling_logJ;
           vlkl2D[row][col] = readingLkl;
           // storing the minimum value and position
           if(!init_lklmin)


### PR DESCRIPTION
Dear @javierrico 

I want to take advantage :-P of your recent GitHub activity and add some branon related changes to gLike. As shown in [Fig.7; right panel](https://arxiv.org/pdf/1905.11154.pdf), you can translate the sgimav limits to the brane tension parameter space. For now, the limits for the brane tension will be calculated and printed to the console. Let me know, if you think that gLike should generate a f(m_{DM}) plot by default.

Cheers,
Tjark