### PR TITLE
Fixes in CMakeLists installation to build singularity containers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,26 +1,33 @@
 cmake_minimum_required(VERSION 3.0)
 project(GLIKE VERSION 0.8.0)
 
-# where to save the .so (.dylib) and .pcm files
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_INSTALL_LIBDIR ${CMAKE_BINARY_DIR}/lib) 
-# where to save the executables
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+# sane defaults for CMAKE_INSTALL_*DIR
+include(GNUInstallDirs)
+# RPATH handling. This makes setting LD_LIBRARY_PATH unecessary
+# as it will compile the path to the libraries into the libraries / executables
+if(APPLE)
+    set(CMAKE_INSTALL_RPATH "@executable_path/../${CMAKE_INSTALL_LIBDIR}")
+else()
+    set(CMAKE_INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
+endif()
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+# make layout in the build directory the same as install directory
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR})
 
 # load ROOT libraries, define a cache variable to enable FITSIO support 
 # if USE_FITSIO is selected, Fitsio is added to the ROOT requirements   
 set(ROOT_REQUIRED_COMPONENTS Minuit)
 option(USE_FITSIO "Enable support for FITS files I/O" OFF)                      
 if(USE_FITSIO)                     
-    list(APPEND ROOT_REQUIRED_COMPONENTS Fitsio)
+    list(APPEND ROOT_REQUIRED_COMPONENTS FITSIO)
 endif()   
 find_package(ROOT REQUIRED ${ROOT_REQUIRED_COMPONENTS})
 message("-- Required ROOT components are: ${ROOT_REQUIRED_COMPONENTS}")
-
 # for ROOT versions < 6
 include(${ROOT_USE_FILE})
 
-# generate glike ROOT.pcm dictionaries
+# generate glike ROOT .pcm dictionaries
 root_generate_dictionary(
     gLikeDict
     ${PROJECT_SOURCE_DIR}/include/Lkl.h
@@ -36,7 +43,6 @@ root_generate_dictionary(
     ${PROJECT_SOURCE_DIR}/include/TemplateLkl.h
     LINKDEF ${PROJECT_SOURCE_DIR}/include/gLikeLinkDef.h
 )
-
 # create a shared library with the generated dictionary
 add_library(
     gLike SHARED 
@@ -53,14 +59,33 @@ add_library(
     ${PROJECT_SOURCE_DIR}/src/TemplateLkl.cc
     gLikeDict
 )
+# make gLike headers public, for usage by other codes
+set(GLIKE_HEADERS
+    ${PROJECT_SOURCE_DIR}/include/Lkl.h
+    ${PROJECT_SOURCE_DIR}/include/ParabolaLkl.h
+    ${PROJECT_SOURCE_DIR}/include/PoissonLkl.h
+    ${PROJECT_SOURCE_DIR}/include/JointLkl.h
+    ${PROJECT_SOURCE_DIR}/include/Iact1dUnbinnedLkl.h
+    ${PROJECT_SOURCE_DIR}/include/Iact1dBinnedLkl.h
+    ${PROJECT_SOURCE_DIR}/include/IactEventListIrf.h
+    ${PROJECT_SOURCE_DIR}/include/MIACTEventListIRF.h
+    ${PROJECT_SOURCE_DIR}/include/FermiTables2016Lkl.h
+    ${PROJECT_SOURCE_DIR}/include/GloryDuckTables2019Lkl.h
+    ${PROJECT_SOURCE_DIR}/include/TemplateLkl.h
+)
+set_target_properties(gLike PROPERTIES PUBLIC_HEADER ${GLIKE_HEADERS})
 # link gLike libraries against ROOT's ones
 target_link_libraries(gLike ${ROOT_LIBRARIES})
 # where to find the header files for the gLike libraries
 target_include_directories(gLike PUBLIC ${PROJECT_SOURCE_DIR}/include)
 # install the gLike libraries in /usr/local/lib
-install(TARGETS gLike DESTINATION lib)
+install(
+    TARGETS gLike
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
 
-# copy scripts, rcfiles, DM and data directories
+# copy scripts, rcfiles, DM and data directories in the build directory
 add_custom_target(copy_dirs ALL
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/include ${CMAKE_BINARY_DIR}/include
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/scripts ${CMAKE_BINARY_DIR}/scripts

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ If you build `gLike` using an older ROOT version, the interface to FITS data for
       `make`         
       and install    
       `make install`    
-      this last step will make gLike libraries available system-wise, i.e. libraries will be saved in `/usr/local/lib` and executables in `/usr/local/bin`.
+      this last step will make gLike libraries available system-wise, i.e. libraries will be saved in `/usr/local/lib` and executables in `/usr/local/bin`. If you do not have root privileges and cannot write into `/usr`, you can specify the path where you want the gLike libraries to be compiled and installed. Alternatives might be `$HOME/.local` or `$HOME/opt`. Pass the their path via the `CMAKE_INSTALL_PREFIX` option, e.g.   
+      `cmake /path/to/the/source/gLike/dir/ -DCMAKE_INSTALL_PREFIX=$HOME/opt # install cmake system-wise without root privileges`
 
 ### load gLike libraries in ROOT
 If you want to load the gLike libraries each time you open ROOT, modify (or create) in your home a `.rootrc` file, inserting (editing) the line

--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ If you build `gLike` using an older ROOT version, the interface to FITS data for
       `make`         
       and install    
       `make install`    
-      this last step will make gLike libraries available system-wise, i.e. libraries will be saved in `/usr/local/lib` and executables in `/usr/local/bin`. If you do not have root privileges and cannot write into `/usr`, you can specify the path where you want the gLike libraries to be compiled and installed. Alternatives might be `$HOME/.local` or `$HOME/opt`. Pass the their path via the `CMAKE_INSTALL_PREFIX` option, e.g.   
-      `cmake /path/to/the/source/gLike/dir/ -DCMAKE_INSTALL_PREFIX=$HOME/opt # install cmake system-wise without root privileges`
+      this last step will make gLike libraries available system-wise, i.e. libraries will be saved in `/usr/local/lib` and executables in `/usr/local/bin`. If you do not have root privileges and cannot write into `/usr`, you can specify the path where you want the gLike libraries to be compiled and installed. Alternatives might be `$HOME/.local` or `$HOME/opt`. Pass the their path via the `CMAKE_INSTALL_PREFIX` option, e.g.       
+      `cmake /path/to/the/source/gLike/dir/ -DCMAKE_INSTALL_PREFIX=$HOME/opt # install cmake without root privileges`      
+      **NOTE** if you do not have root privileges and do not have installed `gLike` in `/usr/local`, but in `$HOME/.local` or `$HOME/opt` remember to add these paths to your `$PATH` to be able to use the executables without giving their full path.
 
 ### load gLike libraries in ROOT
 If you want to load the gLike libraries each time you open ROOT, modify (or create) in your home a `.rootrc` file, inserting (editing) the line


### PR DESCRIPTION
Hi,

I made some fixes to the `cmake` installation as I am trying to produce singularity containers with `gLike`, to onboard our software in the escape software repository.

Anyone (@TjarkMiener, @dkerszberg , @javierrico) willing to try to install with `cmake` and check for example `jointLklDM` is available in your system after installation? I updated the installation instructions.
For me it works on ubuntu (both on my filesystem and in a container).

Cheers!