### PR TITLE
Add the possibility of fast simulations containing a finite signal component

### DIFF
--- a/exec/jointLklDM.cc
+++ b/exec/jointLklDM.cc
@@ -272,7 +272,7 @@ int main(int argc,char* argv[])
   cout << " GeV" << endl;
   
   cout << "*** IRF/DATA PLOTS      : " << (showSamplePlots?   "YES" : "NO") << endl;
-  cout << "*** PARABOlA PLOTS      : " << (showParabolaPlots? "YES" : "NO") << endl;
+  cout << "*** PARABOLA PLOTS      : " << (showParabolaPlots? "YES" : "NO") << endl;
   cout << "*** Plot y-axis range   : " << plotmin << " to " << plotmax << Form(" %s", (isDecay? "s" : "cm^3/s")) << endl;
   cout << "*** EXPORT DATA         : " << (exportData? "YES" : "NO") << endl;
   if(exportData)
@@ -907,7 +907,7 @@ int main(int argc,char* argv[])
   gSystem->Exec(Form("mkdir -p %s/pdf",realPlotDir.Data()));
   gSystem->Exec(Form("mkdir -p %s/jpg",realPlotDir.Data()));
   
-  TString seedTag  = (seed<0? "" : Form("_%d",seed));
+  TString seedTag  = (seed<0? "" : Form("_%04d",seed));
   
   limcanvas->Print(realPlotDir+"root/"+label+"_"+simulationlabel+"_limits"+seedTag+".root");
   limcanvas->Print(realPlotDir+"pdf/" +label+"_"+simulationlabel+"_limits"+seedTag+".pdf");

--- a/exec/jointLklDM.cc
+++ b/exec/jointLklDM.cc
@@ -905,18 +905,15 @@ int main(int argc,char* argv[])
   TString realPlotDir = fPlotsDir+simulationlabel+"/";
   gSystem->Exec(Form("mkdir -p %s/root",realPlotDir.Data()));
   gSystem->Exec(Form("mkdir -p %s/pdf",realPlotDir.Data()));
-  gSystem->Exec(Form("mkdir -p %s/jpg",realPlotDir.Data()));
   
   TString seedTag  = (seed<0? "" : Form("_%04d",seed));
   
   limcanvas->Print(realPlotDir+"root/"+label+"_"+simulationlabel+"_limits"+seedTag+".root");
   limcanvas->Print(realPlotDir+"pdf/" +label+"_"+simulationlabel+"_limits"+seedTag+".pdf");
-  limcanvas->Print(realPlotDir+"jpg/" +label+"_"+simulationlabel+"_limits"+seedTag+".jpg");
   if(showParabolaPlots)
     {
       lklcanvas->Print(realPlotDir+"root/"+label+"_"+simulationlabel+"_2logLVsG"+seedTag+".root");
       lklcanvas->Print(realPlotDir+"pdf/" +label+"_"+simulationlabel+"_2logLVsG"+seedTag+".pdf");
-      lklcanvas->Print(realPlotDir+"jpg/" +label+"_"+simulationlabel+"_2logLVsG"+seedTag+".jpg");
     }
   if(showSamplePlots)
     {
@@ -924,7 +921,6 @@ int main(int argc,char* argv[])
 	{	
 	  hadcanvas[isample]->Print(realPlotDir+"root/"+label+"_"+simulationlabel+Form("_histos_sample%02d",isample)+seedTag+".root");
 	  hadcanvas[isample]->Print(realPlotDir+"pdf/" +label+"_"+simulationlabel+Form("_histos_sample%02d",isample)+seedTag+".pdf");
-	  hadcanvas[isample]->Print(realPlotDir+"jpg/" +label+"_"+simulationlabel+Form("_histos_sample%02d",isample)+seedTag+".jpg");
 	}
     }
     

--- a/exec/jointLklDM.cc
+++ b/exec/jointLklDM.cc
@@ -77,6 +77,7 @@
 #include "TEnv.h"
 #include "TROOT.h"
 #include "TSystem.h"
+#include "TRandom3.h"
 
 #include "Iact1dUnbinnedLkl.h"
 #include "Iact1dBinnedLkl.h"
@@ -88,13 +89,32 @@ using namespace std;
 
 void setDefaultStyle();
 void usage();
-void decode_channel(TObjArray* coefficients, Int_t &nChannels, TString *channelval, Double_t *brval);
+void decode_channel(TObjArray* coefficients, Int_t &nChannels, TString *channelval, Double_t *brval,TString& strchannel,TString& normchannel,Double_t& minmass);
 void compute_branonBR(Float_t &mass, Int_t &nChannels, TString *channelval, Double_t *brval);
 Int_t GetNSkippedMasses(Int_t nm,const Double_t* vm,Double_t minm);
-void builddNdESignal(Lkl* lkl,TString dNdEDir, Int_t nChannels,TString* channelval,Double_t* brval,Float_t mdm,Bool_t isDecay,Bool_t isSimulation);
+void builddNdESignal(Iact1dUnbinnedLkl* lkl,TString dNdEDir, Int_t nChannels,TString* channelval,Double_t* brval,Float_t mdm);
+void readAndWritedNdEpSignal(Iact1dUnbinnedLkl* lkl,TString dNdEpDir,TString normchannel,Float_t mdm);
 TString mprecform(Double_t val);
 
-const Int_t nMaxLkls = 1000;
+// Constants
+const Int_t    nMaxLkls = 1000;
+const Double_t bmass=4.18;
+const Double_t cmass=1.27;
+const Double_t tmass=173;
+const Double_t taumass=1.78;
+const Double_t mumass=0.106;
+const Double_t Wmass=80.4;
+const Double_t Zmass=91.2;
+const Double_t Hmass=125;
+const Double_t gammamass=0;
+const Double_t pi0mass=0.135;
+const Double_t emass=0.511e-3;
+const Double_t int1mass=120.0;
+const Double_t int2mass=2.044e-3;
+const Double_t int3mass=0.424;
+const Double_t int4mass=7.2;
+const Double_t branonmass=0;
+
 
 int main(int argc,char* argv[])
 {
@@ -157,10 +177,10 @@ int main(int argc,char* argv[])
   TString  provval           = env->GetValue("jointLklDM.dNdEpSignalDir","-");
   TString  fdNdEpSignalDir   = fInputDataPath+"/"+provval+"/";
   TString  massList          = env->GetValue("jointLklDM.MassList","");
-  Float_t  mcsv              = env->GetValue("jointLklDM.mcsv",0.);    // value of <sv> assumed for simulations
-  Float_t  mcmass            = env->GetValue("jointLklDM.mcmass",0.);  // value of DM mass assumed for simulations
-  TString  mcChannel         = env->GetValue("jointLklDM.mcChannel","bb");
-  TString  mcProcess         = env->GetValue("jointLklDM.mcProcess","ann");     
+  Float_t  mcalpha           = env->GetValue("jointLklDM.mcalpha",0.);    // value of alpha (<sv> or 1/tau) assumed for simulations
+  Float_t  mcmass            = env->GetValue("jointLklDM.mcMass",0.);     // value of DM mass assumed for simulations
+  TString  mcchannel         = env->GetValue("jointLklDM.mcChannel","bb");
+  TString  mcprocess         = env->GetValue("jointLklDM.mcProcess","ann");     
   Bool_t   exportData        = env->GetValue("jointLklDM.exportData",kFALSE);
   Double_t svMin             = env->GetValue("jointLklDM.exportSvMin",0.);
   Double_t svMax             = env->GetValue("jointLklDM.exportSvMax",0.);
@@ -178,70 +198,45 @@ int main(int argc,char* argv[])
   Bool_t  isSimulation       = seed>=0;
   Bool_t  ioHdNdEpSignal     = provval.CompareTo("-");
   Bool_t  isDecay            = !process.CompareTo("dec",TString::kIgnoreCase);
+  Bool_t  isMCDecay          = !mcprocess.CompareTo("dec",TString::kIgnoreCase);
   
   // define some labels according to input data
   TString simulationlabel    = (isSimulation?  "MC"    : "Data");
   TString strprocess         = (isDecay?       "Decay" : "Annihilation");
+  TString mcstrprocess       = (isMCDecay?     "Decay" : "Annihilation");
   
   // Decode the channel and save the decoded channels and branching ratios in channelval and brval, respectively.
   TObjArray* coefficients = channel.Tokenize("+");
   Int_t nChannels = coefficients->GetEntries();
   TString* channelval = new TString[nChannels];
   Double_t* brval = new Double_t[nChannels];
-  // call the function that decodes the coefficients of the channel
-  decode_channel(coefficients,nChannels,channelval,brval);
-
-  // annihilation/decay channel string
   TString strchannel;
   TString normchannel;
   Double_t minmass = 0;
-  std::ostringstream buffer;
-  for (Int_t iChannel = 0; iChannel < nChannels; iChannel++)
-    {
-      if(nChannels == 1) strchannel = normchannel = "";
-      else
-          if(iChannel == 0) 
-            {
-              Float_t rounded_brval = ((Int_t)(brval[iChannel] * 100 + .5) / 100.0);
-              buffer << rounded_brval;
-              strchannel  = (TString) buffer.str().substr(0, 4) + "#upoint";
-              normchannel = (TString) buffer.str().substr(0, 4) + "*";
-            }
-          else
-            {
-              Float_t rounded_brval = ((Int_t)(brval[iChannel] * 100 + .5) / 100.0);
-              buffer.clear();
-              buffer.str("");
-              buffer << rounded_brval;
-              strchannel.Append("#plus" + buffer.str().substr(0, 4) + "#upoint");
-              normchannel.Append("+" + buffer.str().substr(0, 4) + "*");
-            }
-      normchannel.Append(channelval[iChannel]);
-
-      if     (!channelval[iChannel].CompareTo("bb",TString::kIgnoreCase))         {strchannel.Append("b#bar{b}");              minmass=5;}
-      else if(!channelval[iChannel].CompareTo("cc",TString::kIgnoreCase))         {strchannel.Append("c#bar{c}");              minmass=1.3;}
-      else if(!channelval[iChannel].CompareTo("tt",TString::kIgnoreCase))         {strchannel.Append("t#bar{t}");              minmass=173;}
-      else if(!channelval[iChannel].CompareTo("tautau",TString::kIgnoreCase))     {strchannel.Append("#tau^{+}#tau^{-}");      minmass=1.8;}
-      else if(!channelval[iChannel].CompareTo("mumu",TString::kIgnoreCase))       {strchannel.Append("#mu^{+}#mu^{-}");        minmass=0.106;}
-      else if(!channelval[iChannel].CompareTo("WW",TString::kIgnoreCase))         {strchannel.Append("W^{+}W^{-}");            minmass=80.3;}
-      else if(!channelval[iChannel].CompareTo("ZZ",TString::kIgnoreCase))         {strchannel.Append("ZZ");                    minmass=91.2;}
-      else if(!channelval[iChannel].CompareTo("hh",TString::kIgnoreCase))         {strchannel.Append("HH");                    minmass=125;}
-      else if(!channelval[iChannel].CompareTo("gammagamma",TString::kIgnoreCase)) {strchannel.Append("#gamma#gamma");          minmass=0;}
-      else if(!channelval[iChannel].CompareTo("pi0pi0",TString::kIgnoreCase))     {strchannel.Append("#pi^{0}#pi^{0}");        minmass=0.135;}
-      else if(!channelval[iChannel].CompareTo("gammapi0",TString::kIgnoreCase))   {strchannel.Append("#pi^{0}#gamma");         minmass=0.135/2.;}
-      else if(!channelval[iChannel].CompareTo("pi0gamma",TString::kIgnoreCase))   {strchannel.Append("#pi^{0}#gamma");         minmass=0.135/2.;}
-      else if(!channelval[iChannel].CompareTo("ee",TString::kIgnoreCase))         {strchannel.Append("e^{+}e^{-}");            minmass=0.511e-3;}
-      else if(!channelval[iChannel].CompareTo("nuenue",TString::kIgnoreCase))     {strchannel.Append("#nu_{e}#nu_{e}");        minmass=120.0;}
-      else if(!channelval[iChannel].CompareTo("numunumu",TString::kIgnoreCase))   {strchannel.Append("#nu_{#mu}#nu_{#mu}");    minmass=120.0;}
-      else if(!channelval[iChannel].CompareTo("nutaunutau",TString::kIgnoreCase)) {strchannel.Append("#nu_{#tau}#nu_{#tau}");  minmass=120.0;}
-      else if(!channelval[iChannel].CompareTo("VV-4e",TString::kIgnoreCase))      {strchannel.Append("VV-4e");                 minmass=2.044e-3;}
-      else if(!channelval[iChannel].CompareTo("VV-4mu",TString::kIgnoreCase))     {strchannel.Append("VV-4#mu");               minmass=0.424;}
-      else if(!channelval[iChannel].CompareTo("VV-4tau",TString::kIgnoreCase))    {strchannel.Append("VV-4#tau");              minmass=7.2;}
-      else if(!channelval[iChannel].CompareTo("branon",TString::kIgnoreCase))     {strchannel.Append("branon");                minmass=0;}
-      else strchannel = "";
-    }
+  // call the function that decodes the coefficients of the channel
+  decode_channel(coefficients,nChannels,channelval,brval,strchannel,normchannel,minmass);
   if(isDecay) minmass*=2;
-  
+			     
+  // Decode the mc channel and save the decoded channels and branching ratios in mcchannelval and mcbrval, respectively.
+  TObjArray* mccoefficients = mcchannel.Tokenize("+");
+  Int_t mcnChannels = mccoefficients->GetEntries();
+  TString* mcchannelval = new TString[mcnChannels];
+  Double_t* mcbrval = new Double_t[mcnChannels];
+  TString mcstrchannel;
+  TString mcnormchannel;
+  Double_t mcminmass = 0;
+  // call the function that decodes the coefficients of the channel
+  if(isSimulation)
+    {
+      decode_channel(mccoefficients,mcnChannels,mcchannelval,mcbrval,mcstrchannel,mcnormchannel,mcminmass);
+      if(isMCDecay) mcminmass*=2;
+      if(mcmass < mcminmass)
+	{
+	  cout << " ## Oops! Asking to simulate too low mass: " << mcmass << " vs max: " << mcminmass << " <---------------- FATAL ERROR!!!"<< endl;
+	  exit(1);
+	}
+    }
+      
   // Remove mass values below kinematical threshold
   Int_t           nskippedmass = GetNSkippedMasses(nmass0,massval0,minmass);
   Int_t           nmass        = nmass0-nskippedmass; 
@@ -259,8 +254,13 @@ int main(int argc,char* argv[])
   if(isSimulation)
     {
       cout << " ** Seed                     : " << seed << endl;
-      cout << " ** <sv>_MC                  : " << mcsv << " cm^3/s" << endl;
-      cout << " ** m_MC                     : " << mcmass << " GeV" << endl;
+      cout << " ** alpha_MC                 : " << mcalpha << " cm^3/s or 1/s" << endl;
+      if(mcalpha>0)
+	{
+	  cout << " ** m_MC                     : " << mcmass << " GeV" << endl;
+	  cout << " ** PROCESS MC               : " << mcstrprocess << endl;
+	  cout << " ** CHANNEL MC               : " << mcchannel << endl;
+	}
     }
   cout << "*** G IS POSITIVE            : " << (isGpositive? "YES" : "NO") << endl;
       
@@ -297,12 +297,14 @@ int main(int argc,char* argv[])
   // The classes composing the joint likelihood
   Lkl** lkl    = new Lkl*[nMaxLkls];
   Lkl** sample = new Lkl*[nMaxLkls];
+
   
   // read rc file for likelihood construction
   cout << "****************************************************************" << endl;
   cout << "*** CONFIGURING Lkl OBJECTS " << endl;
-  Int_t nLkls = 0;
+  Int_t nLkls    = 0;
   Int_t nsamples = 0;
+  TRandom3* rdm  = new TRandom3(seed);
   for(Int_t iLkl=0;iLkl<nMaxLkls;iLkl++)
     {
       // look for likelihood entries in the rc file
@@ -333,58 +335,66 @@ int main(int argc,char* argv[])
       inputString+=(" path="+fInputDataPath);
 
       // create the proper object according to classType 
-      if(classType.CompareTo("Iact1dUnbinnedLkl")==0)
-	{	  
-	  lkl[iLkl] =  new Iact1dUnbinnedLkl(inputString);
-	  lkl[iLkl]->SetName(Form("Iact1dUnbinnedLkl_%02d",iLkl));
-
-	  // save as sample (as opposed to JointLkl)
-	  sample[nsamples++] = lkl[iLkl];
-	  	  
-	  // if it's simulation of the null hypothesis, we can already simulate the data sample
-	  if(isSimulation && mcsv==0)
-	    {
-	      cout << "  * Simulating observations for <sv> = " << mcsv << endl;			  
-	      if(dynamic_cast<Iact1dUnbinnedLkl*>(lkl[iLkl])->SimulateDataSamples(seed,mcsv))
-		{
-		  cout << " ## Oops! Cannot simulate samples for " << lkl[iLkl]->GetName() << " <---------------- FATAL ERROR!!!"<< endl;
-		  exit(1);
-		}
-	    }
-	  else
-	    if(dynamic_cast<Iact1dUnbinnedLkl*>(lkl[iLkl])->GetNon()<1)
-	      {
-		  cout << " ## Oops! No data (from input or simulated) associated to " << lkl[iLkl]->GetName() << " <---------------- FATAL ERROR!!!"<< endl;
-		  exit(1);
-	      }	 	      
-	}
-      else if(classType.CompareTo("Iact1dBinnedLkl")==0)
+      if(classType.CompareTo("Iact1dUnbinnedLkl")==0 || classType.CompareTo("Iact1dBinnedLkl")==0)
 	{
-	  // read input string
-	  lkl[iLkl] =  new Iact1dBinnedLkl(inputString);
-
-	  // save as sample (as opposed to JointLkl)
-	  sample[nsamples++] = lkl[iLkl];
-
-	  // configure
-	  lkl[iLkl]->SetName(Form("Iact1dBinnedLkl_%02d",iLkl));	  
-
-	  // if it's simulation of the null hypothesis, we can already simulate the data sample
-	  if(isSimulation && mcsv==0)
+	  Iact1dUnbinnedLkl* fullLkl = NULL;
+	  if(classType.CompareTo("Iact1dUnbinnedLkl")==0)
 	    {
-	      cout << "  * Simulating observations for <sv> = " << mcsv << endl;       		  
-	      if(dynamic_cast<Iact1dBinnedLkl*>(lkl[iLkl])->SimulateDataSamples(seed,mcsv))
+	      lkl[iLkl] =  new Iact1dUnbinnedLkl(inputString);
+	      lkl[iLkl]->SetName(Form("Iact1dUnbinnedLkl_%02d",iLkl));
+	      fullLkl = dynamic_cast<Iact1dUnbinnedLkl*>(lkl[iLkl]);
+	    }
+	  else if(classType.CompareTo("Iact1dBinnedLkl")==0)
+	    {
+	      lkl[iLkl] =  new Iact1dBinnedLkl(inputString);
+	      lkl[iLkl]->SetName(Form("Iact1dBinnedLkl_%02d",iLkl));
+	      fullLkl = dynamic_cast<Iact1dBinnedLkl*>(lkl[iLkl]);
+	    }
+	  
+	  // save as sample (as opposed to JointLkl)
+	  sample[nsamples++] = fullLkl;
+	  	  
+	  // if it's simulation, then simulate
+	  if(isSimulation)
+	    {
+	      // Pathological cases
+	      if(mcalpha<0 || mcmass<=0)
 		{
-		  cout << " ## Oops! Cannot simulate samples for " << lkl[iLkl]->GetName() << " <---------------- FATAL ERROR!!!"<< endl;
+		  cout << " ## Oops! Unreasonable simulation conditions (mcalpha=" << mcalpha << ", mcmass=" <<mcmass <<") <---------------- FATAL ERROR!!!"<< endl;
+		  exit(1);
+		}
+
+	      if(mcalpha>0)
+		cout << "  * Simulating observations for alpha = " << mcalpha << ", mass = " << mcmass << ", process = " << mcprocess << ", mcchannel = " << mcchannel << endl;
+	      else
+		cout << "  * Simulating observations for alpha = " << mcalpha <<  endl;
+	      Float_t mcmdm  = (isMCDecay? mcmass/2. : mcmass);
+	      
+	      // if we are simulating signal, we need the pdf
+	      if(mcalpha>0)
+		{
+		  builddNdESignal(fullLkl,fdNdEDir,mcnChannels,mcchannelval,mcbrval,mcmdm);
+		  if(ioHdNdEpSignal)
+		    readAndWritedNdEpSignal(fullLkl,fdNdEpSignalDir,mcnormchannel,mcmdm);
+
+		  // Set the units of g so that the value of <sv> or 1/<tau> can be converted into g
+		  if(isMCDecay)
+		    fullLkl->SetDMDecayUnitsForG(mcmass);
+		  else	      
+		    fullLkl->SetDMAnnihilationUnitsForG(mcmass);   
+		}
+	      //call the actual simulations
+	      if(fullLkl->SimulateDataSamples(mcalpha,rdm))
+		{
+		  cout << " ## Oops! Cannot simulate samples for " << fullLkl->GetName() << " <---------------- FATAL ERROR!!!"<< endl;
 		  exit(1);
 		}
 	    }
-	  else
-	    if(dynamic_cast<Iact1dBinnedLkl*>(lkl[iLkl])->GetNon()<1)
-	      {
-		cout << " ## Oops! No data (from input or simulated) associated to " << lkl[iLkl]->GetName() << " <---------------- FATAL ERROR!!!"<< endl;
-		exit(1);
-	      }	 
+	  else if(fullLkl->GetNon()<1)
+	    {
+	      cout << " ## Oops! No data (from input or simulated) associated to " << lkl[iLkl]->GetName() << " <---------------- FATAL ERROR!!!"<< endl;
+	      exit(1);
+	    }	 	      
 	}
       else if(classType.CompareTo("JointLkl")==0)
 	{	  
@@ -497,7 +507,9 @@ int main(int argc,char* argv[])
       else if(parLkl>=0)
 	dynamic_cast<JointLkl*>(lkl[parLkl])->AddSample(lkl[iLkl]);
     } // end of loop over likelihood terms in the rc file
+  delete rdm;
 
+  
   if(nLkls<2)
     {
       cout << " ## Oops! there must be at least 2 lkl terms... but there are " << nLkls << " <---------------- FATAL ERROR!!!"<< endl;
@@ -595,72 +607,26 @@ int main(int argc,char* argv[])
 
       // Loop over samples to read the dN/dE and dN/dE' histos for signal from files
       ///////////////////////////////////////////////////////////////////////////////////////////////
-      Bool_t saveHistosInFile=kFALSE;
       cout << " *** Read or compute dN/dE and dN/dE' histos for each samples:" << endl;
       for(Int_t isample=0;isample<nLkls;isample++)
         {
 	  if(!strcmp(lkl[isample]->ClassName(),"Iact1dUnbinnedLkl") || !strcmp(lkl[isample]->ClassName(),"Iact1dBinnedLkl"))
 	    {
-	      builddNdESignal(lkl[isample],fdNdEDir,nChannels,channelval,brval,mdm,isDecay,isSimulation);
-
-	      // Read or create dN/dE' for signal
+	       // casted pointer (for less messy code)
 	      Iact1dUnbinnedLkl* fullLkl = NULL;
 	      if(!strcmp(lkl[isample]->ClassName(),"Iact1dUnbinnedLkl")) fullLkl = dynamic_cast<Iact1dUnbinnedLkl*>(lkl[isample]);
 	      if(!strcmp(lkl[isample]->ClassName(),"Iact1dBinnedLkl"))   fullLkl = dynamic_cast<Iact1dBinnedLkl*>(lkl[isample]);
-	      TString dNdEpSignalFileName;
-	      if(ioHdNdEpSignal)
-		{
-		  TString dNdEpSignalFileNameForm = fdNdEpSignalDir+"dNdEpSignal_"+fullLkl->GetName()+"_"+normchannel+Form("_m%s",mprecform(mdm).Data())+".root";
-		  dNdEpSignalFileName = Form(dNdEpSignalFileNameForm,mdm);
-		  cout << "   * Reading dN/dE' for signal from file " << dNdEpSignalFileName << "... " << flush;
-		  
-		  
-		  // if file does not exist, create dNdEpSignal histo (it will be saved in file later)
-		  if(fullLkl->ReaddNdEpSignal(dNdEpSignalFileName))
-		    {
-		      cout << endl << "     Not found! dNdEpSignal histo will be calculated and saved in file " << dNdEpSignalFileName << endl;
-		      saveHistosInFile=kTRUE;
-		    }
-		  // if file exists, read histo and use it
-		  else
-		    cout << "Ok!" << endl;	   	      
-		}
 	      
-	      // Set the units of g for the different samples (this also creates the fHdNdEpSignal histo
+	      builddNdESignal(fullLkl,fdNdEDir,nChannels,channelval,brval,mdm);
+	      if(ioHdNdEpSignal)
+		readAndWritedNdEpSignal(fullLkl,fdNdEpSignalDir,normchannel,mdm);
+
+	      // Set the units of g for the different samples (this also creates the fHdNdEpSignal histo)
 	      if(isDecay)
 		fullLkl->SetDMDecayUnitsForG(mass);
 	      else	      
-		fullLkl->SetDMAnnihilationUnitsForG(mass);
-	      
-	      // in case simulations were requested with DM cont, do them now
-	      if(isSimulation && mcsv>0 && mcmass>0)
-		{		  
-		  cout << "  * Simulating observations for <sv> = " << mcsv << " and m_DM = " << mcmass << endl;
-		  
-		  if(fullLkl->SimulateDataSamples(seed,mcsv))
-		    {
-		      cout << " ## Oops! Cannot simulate samples for " << fullLkl->GetName() << " <---------------- FATAL ERROR!!!"<< endl;
-		      exit(1);
-		    }
-		}	     	      
-	      
-	      // Save the dN_signal/dE' created in the SetDMAnnihilationUnitsForG call
-	      if(ioHdNdEpSignal && saveHistosInFile)
-		{
-		  // saving fHdNdEpSignal histo
-		  gSystem->Exec(Form("mkdir -p %s",fdNdEpSignalDir.Data()));
-		  
-		  TFile* dNdEpSignalFile = new TFile(dNdEpSignalFileName,"RECREATE");
-		  TH1F*  hdNdEpSignal    = new TH1F(*fullLkl->GetHdNdEpSignal());
-		  hdNdEpSignal->SetDirectory(0);
-		  cout << "     Saving dN/dE' signal histo to " << dNdEpSignalFileName << "... " << flush;
-		  hdNdEpSignal->Write();
-		  dNdEpSignalFile->Close();
-		  delete dNdEpSignalFile;
-		  delete hdNdEpSignal;
-		  cout << "Ok!" << endl;
-		}
-	    }
+		fullLkl->SetDMAnnihilationUnitsForG(mass);	    	     	      	      
+	    } // end of case Iact1dUnbinnedLkl or Iact1dBinnedLkl
           else if(!strcmp(lkl[isample]->ClassName(),"GloryDuckTables2019Lkl"))
             {
               GloryDuckTables2019Lkl* gdLkl = dynamic_cast<GloryDuckTables2019Lkl*>(lkl[isample]);
@@ -675,17 +641,17 @@ int main(int argc,char* argv[])
 
       // Plot IRF and data
       /////////////////////
+      
       if(showSamplePlots)
-	// loop over samples
 	for(Int_t isample=0;isample<nsamples;isample++)
 	  {
 	    Iact1dUnbinnedLkl* fullLkl = dynamic_cast<Iact1dUnbinnedLkl*>(sample[isample]);
 	    
 	    if(!Init_canvas_samples)
 	      {
-		hadcanvas[isample] = fullLkl->PlotHistosAndData();
-		hadcanvas[isample]->SetName(Form("hadcanvas_%d",isample));
-		hadcanvas[isample]->SetTitle(Form("IRFs and data for sample %d",isample));
+		hadcanvas[isample] = new TCanvas(Form("hadcanvas_%d",isample),Form("IRFs and data for sample %d",isample), 1000, 1500);
+		fullLkl->PlotHistosAndData(hadcanvas[isample]);
+		
 		hadcanvas[isample]->cd(5);
 		TLatex* ltchannel;
 		if(nChannels == 1) ltchannel = new TLatex(0.8,0.8,strchannel);
@@ -693,36 +659,37 @@ int main(int argc,char* argv[])
 		ltchannel->SetTextSize(0.055);
 		ltchannel->SetNDC();
 		ltchannel->Draw();
-	        if (!Init_canvas_samples && isample==nsamples-1) Init_canvas_samples = kTRUE;
+		if (!Init_canvas_samples && isample==nsamples-1) Init_canvas_samples = kTRUE;
 	      }
 	    else
 	      {
 		hadcanvas[isample]->cd(5);
 		TH1F* hdNdESignal = new TH1F(*fullLkl->GetHdNdESignal());
+		hdNdESignal->Scale(hdNdESignal->GetBinContent(0));
 		hdNdESignal->SetLineStyle((imass+1)%8);
-		hdNdESignal->DrawCopy("same");
+		hdNdESignal->DrawCopy("hist same");
 		delete hdNdESignal;
-
+		
 		hadcanvas[isample]->cd(6);
 		TH1F* hdNdEpSignal = new TH1F(*fullLkl->GetHdNdEpSignal());
+		hdNdEpSignal->Scale(hdNdEpSignal->GetBinContent(0));
 		hdNdEpSignal->SetLineStyle((imass+1)%8);
-		hdNdEpSignal->Scale(hdNdEpSignal->GetBinContent(0));				
-		hdNdEpSignal->DrawCopy("same");
+		hdNdEpSignal->DrawCopy("hist same");
 		delete hdNdEpSignal;
-
+		
 		if(fullLkl->GetHdNdEpSignalOff())
 		  {
 		    TH1F* hdNdEpSignalOff = new TH1F(*fullLkl->GetHdNdEpSignalOff());
 		    hdNdEpSignalOff->SetLineStyle((imass+1)%8);
 		    hdNdEpSignalOff->Scale(hdNdEpSignalOff->GetBinContent(0));				
-		    hdNdEpSignalOff->DrawCopy("same");
+		    hdNdEpSignalOff->DrawCopy("hist same");
 		    delete hdNdEpSignalOff;
 		  }
 	      }	    
 	    gPad->Modified();
 	    gPad->Update();
 	  } // end of loop over samples
-      
+
       // compute -2logLkl vs g for precise limit computation
       cout << " *** Computing -2logL (parabola) vs g:" << endl;
       if(!lkl[0]->ComputeLklVsG())
@@ -938,26 +905,34 @@ int main(int argc,char* argv[])
   TString realPlotDir = fPlotsDir+simulationlabel+"/";
   gSystem->Exec(Form("mkdir -p %s/root",realPlotDir.Data()));
   gSystem->Exec(Form("mkdir -p %s/pdf",realPlotDir.Data()));
+  gSystem->Exec(Form("mkdir -p %s/jpg",realPlotDir.Data()));
   
   TString seedTag  = (seed<0? "" : Form("_%d",seed));
   
   limcanvas->Print(realPlotDir+"root/"+label+"_"+simulationlabel+"_limits"+seedTag+".root");
   limcanvas->Print(realPlotDir+"pdf/" +label+"_"+simulationlabel+"_limits"+seedTag+".pdf");
+  limcanvas->Print(realPlotDir+"jpg/" +label+"_"+simulationlabel+"_limits"+seedTag+".jpg");
   if(showParabolaPlots)
     {
       lklcanvas->Print(realPlotDir+"root/"+label+"_"+simulationlabel+"_2logLVsG"+seedTag+".root");
       lklcanvas->Print(realPlotDir+"pdf/" +label+"_"+simulationlabel+"_2logLVsG"+seedTag+".pdf");
+      lklcanvas->Print(realPlotDir+"jpg/" +label+"_"+simulationlabel+"_2logLVsG"+seedTag+".jpg");
     }
-  if(showSamplePlots) 
-    for(Int_t isample=0;isample<nsamples;isample++)
-      {	
-	hadcanvas[isample]->Print(realPlotDir+"root/"+label+"_"+simulationlabel+Form("_histos_sample%02d",isample)+seedTag+".root");
-	hadcanvas[isample]->Print(realPlotDir+"pdf/" +label+"_"+simulationlabel+Form("_histos_sample%02d",isample)+seedTag+".pdf");
-      }
+  if(showSamplePlots)
+    {
+      for(Int_t isample=0;isample<nsamples;isample++)
+	{	
+	  hadcanvas[isample]->Print(realPlotDir+"root/"+label+"_"+simulationlabel+Form("_histos_sample%02d",isample)+seedTag+".root");
+	  hadcanvas[isample]->Print(realPlotDir+"pdf/" +label+"_"+simulationlabel+Form("_histos_sample%02d",isample)+seedTag+".pdf");
+	  hadcanvas[isample]->Print(realPlotDir+"jpg/" +label+"_"+simulationlabel+Form("_histos_sample%02d",isample)+seedTag+".jpg");
+	}
+    }
     
   // Clean up and close 
   /////////////////////
   delete [] lkl;
+  if(showSamplePlots)
+    delete [] hadcanvas;
 }
 
 Int_t GetNSkippedMasses(Int_t nm,const Double_t* vm,Double_t minm)
@@ -1017,7 +992,7 @@ void setDefaultStyle()
 }
 
 // Decode the channel and save the decoded channels and branching ratios in channelval and brval, respectively.
-void decode_channel(TObjArray* coefficients, Int_t &nChannels, TString *channelval, Double_t *brval)
+void decode_channel(TObjArray* coefficients, Int_t &nChannels, TString *channelval, Double_t *brval,TString& strchannel,TString& normchannel,Double_t& minmass)
 {
   Float_t sumBR = 0.0;
   TString factorstring, coefficientstring;
@@ -1076,6 +1051,55 @@ void decode_channel(TObjArray* coefficients, Int_t &nChannels, TString *channelv
   // Normalize the branching ratios if they differ from 1.0 (100%)
   if (sumBR != 1.0)
       for (Int_t iChannel = 0; iChannel < nChannels; iChannel++) brval[iChannel] /= sumBR;
+  
+  // annihilation/decay channel string and minimum mass
+  std::ostringstream buffer;
+  for (Int_t iChannel = 0; iChannel < nChannels; iChannel++)
+    {
+      if(nChannels == 1) strchannel = normchannel = "";
+      else
+	if(iChannel == 0) 
+	  {
+	    Float_t rounded_brval = ((Int_t)(brval[iChannel] * 100 + .5) / 100.0);
+	    buffer << rounded_brval;
+	    strchannel  = (TString) buffer.str().substr(0, 4) + "#upoint";
+	    normchannel = (TString) buffer.str().substr(0, 4) + "*";
+	  }
+	else
+	  {
+	    Float_t rounded_brval = ((Int_t)(brval[iChannel] * 100 + .5) / 100.0);
+	    buffer.clear();
+	    buffer.str("");
+	    buffer << rounded_brval;
+	    strchannel.Append("#plus" + buffer.str().substr(0, 4) + "#upoint");
+	    normchannel.Append("+" + buffer.str().substr(0, 4) + "*");
+	  }
+      normchannel.Append(channelval[iChannel]);
+      minmass=0;
+      
+      if     (!channelval[iChannel].CompareTo("bb",TString::kIgnoreCase))         {strchannel.Append("b#bar{b}");              minmass=TMath::Max(minmass,bmass);}
+      else if(!channelval[iChannel].CompareTo("cc",TString::kIgnoreCase))         {strchannel.Append("c#bar{c}");              minmass=TMath::Max(minmass,cmass);}
+      else if(!channelval[iChannel].CompareTo("tt",TString::kIgnoreCase))         {strchannel.Append("t#bar{t}");              minmass=TMath::Max(minmass,tmass);}
+      else if(!channelval[iChannel].CompareTo("tautau",TString::kIgnoreCase))     {strchannel.Append("#tau^{+}#tau^{-}");      minmass=TMath::Max(minmass,taumass);}
+      else if(!channelval[iChannel].CompareTo("mumu",TString::kIgnoreCase))       {strchannel.Append("#mu^{+}#mu^{-}");        minmass=TMath::Max(minmass,mumass);}
+      else if(!channelval[iChannel].CompareTo("WW",TString::kIgnoreCase))         {strchannel.Append("W^{+}W^{-}");            minmass=TMath::Max(minmass,Wmass);}
+      else if(!channelval[iChannel].CompareTo("ZZ",TString::kIgnoreCase))         {strchannel.Append("ZZ");                    minmass=TMath::Max(minmass,Zmass);}
+      else if(!channelval[iChannel].CompareTo("hh",TString::kIgnoreCase))         {strchannel.Append("HH");                    minmass=TMath::Max(minmass,Hmass);}
+      else if(!channelval[iChannel].CompareTo("gammagamma",TString::kIgnoreCase)) {strchannel.Append("#gamma#gamma");          minmass=TMath::Max(minmass,gammamass);}
+      else if(!channelval[iChannel].CompareTo("pi0pi0",TString::kIgnoreCase))     {strchannel.Append("#pi^{0}#pi^{0}");        minmass=TMath::Max(minmass,pi0mass);}
+      else if(!channelval[iChannel].CompareTo("gammapi0",TString::kIgnoreCase))   {strchannel.Append("#pi^{0}#gamma");         minmass=TMath::Max(minmass,pi0mass/2.);}
+      else if(!channelval[iChannel].CompareTo("pi0gamma",TString::kIgnoreCase))   {strchannel.Append("#pi^{0}#gamma");         minmass=TMath::Max(minmass,pi0mass/2.);}
+      else if(!channelval[iChannel].CompareTo("ee",TString::kIgnoreCase))         {strchannel.Append("e^{+}e^{-}");            minmass=TMath::Max(minmass,emass);}
+      else if(!channelval[iChannel].CompareTo("nuenue",TString::kIgnoreCase))     {strchannel.Append("#nu_{e}#nu_{e}");        minmass=TMath::Max(minmass,int1mass);}
+      else if(!channelval[iChannel].CompareTo("numunumu",TString::kIgnoreCase))   {strchannel.Append("#nu_{#mu}#nu_{#mu}");    minmass=TMath::Max(minmass,int1mass);}
+      else if(!channelval[iChannel].CompareTo("nutaunutau",TString::kIgnoreCase)) {strchannel.Append("#nu_{#tau}#nu_{#tau}");  minmass=TMath::Max(minmass,int1mass);}
+      else if(!channelval[iChannel].CompareTo("VV-4e",TString::kIgnoreCase))      {strchannel.Append("VV-4e");                 minmass=TMath::Max(minmass,int2mass);}
+      else if(!channelval[iChannel].CompareTo("VV-4mu",TString::kIgnoreCase))     {strchannel.Append("VV-4#mu");               minmass=TMath::Max(minmass,int3mass);}
+      else if(!channelval[iChannel].CompareTo("VV-4tau",TString::kIgnoreCase))    {strchannel.Append("VV-4#tau");              minmass=TMath::Max(minmass,int4mass);}
+      else if(!channelval[iChannel].CompareTo("branon",TString::kIgnoreCase))     {strchannel.Append("branon");                minmass=TMath::Max(minmass,branonmass);}
+      else strchannel = "";
+    }
+
 }
 
 // Compute the branching ratios for the branon model for each DM mass and save the channels and branching ratios in channelval and brval, respectively.
@@ -1084,7 +1108,7 @@ void compute_branonBR(Float_t &mass, Int_t &nChannels, TString *channelval, Doub
     // The included annihilation channels for the branon model
     TString particle_type[9]        = {"bb","cc","tt","ee","mumu","tautau","WW","ZZ","hh"};
     // The corresponding masses in GeV
-    Float_t particle_mass[9]        = {4.18,1.28,173.1,0.511e-3,0.106,1.7768,80.39,91.19,125.0};
+    Double_t particle_mass[9]        = {bmass,cmass,tmass,emass,mumass,taumass,Wmass,Zmass,Hmass};
     // Classification of the elementary particles
     TString dirac_fermions          = "cc_tt_bb_ee_mumu_tautau";
     TString gauge_bosons            = "WW_ZZ";
@@ -1122,17 +1146,12 @@ void compute_branonBR(Float_t &mass, Int_t &nChannels, TString *channelval, Doub
       }
   }
 
-void builddNdESignal(Lkl* lkl,TString dNdEDir, Int_t nChannels,TString* channelval,Double_t* brval,Float_t mdm,Bool_t isDecay,Bool_t isSimulation)
-{
-  // casted pointer (for less messy code)
-  Iact1dUnbinnedLkl* fullLkl = NULL;
-  if(!strcmp(lkl->ClassName(),"Iact1dUnbinnedLkl")) fullLkl = dynamic_cast<Iact1dUnbinnedLkl*>(lkl);
-  if(!strcmp(lkl->ClassName(),"Iact1dBinnedLkl"))   fullLkl = dynamic_cast<Iact1dBinnedLkl*>(lkl);
-	      
-  cout << "  ** Building histos for sample " << fullLkl->GetName() << ":" << endl;	      
+void builddNdESignal(Iact1dUnbinnedLkl* lkl,TString dNdEDir, Int_t nChannels,TString* channelval,Double_t* brval,Float_t mdm)
+{	      
+  cout << "  ** Building histos for sample " << lkl->GetName() << ":" << endl;	      
 
   // Delete existing fHdNdESignal and create empty one
-  fullLkl->ResetdNdESignal();
+  lkl->ResetdNdESignal();
   
   for(Int_t iChannel=0;iChannel<nChannels;iChannel++)	     
     if(brval[iChannel] != 0.0)
@@ -1141,7 +1160,7 @@ void builddNdESignal(Lkl* lkl,TString dNdEDir, Int_t nChannels,TString* channelv
 	if(!channelval[iChannel].CompareTo("gammagamma",TString::kIgnoreCase))
 	  {
 	    cout << "   * Setting dN/dE for a monochromatic line at energy " << mdm  << " GeV with BR = " << brval[iChannel] << " ... " << flush;
-	    if(fullLkl->AdddNdESignalFunction("line",mdm,2,brval[iChannel]))
+	    if(lkl->AdddNdESignalFunction("line",mdm,2,brval[iChannel]))
 	      {
 		cout << "Failed! <---------------- FATAL ERROR!!!" << endl;
 		exit(1);
@@ -1156,7 +1175,7 @@ void builddNdESignal(Lkl* lkl,TString dNdEDir, Int_t nChannels,TString* channelv
 	    Float_t emax =  mdm/2.*(1+TMath::Sqrt(1-mpi*mpi/(mdm*mdm)));
 	    cout << "   * Setting dN/dE for XX->pi0pi0 for mass = " << mdm  << " GeV (i.e. box between " << emin << " and " << emax << " GeV) with BR = " << brval[iChannel] << "... " << flush;
 	    
-	    if(fullLkl->AdddNdESignalFunction("box",emin,emax,4,brval[iChannel]))
+	    if(lkl->AdddNdESignalFunction("box",emin,emax,4,brval[iChannel]))
 	      {
 		cout << "Failed! <---------------- FATAL ERROR!!!" << endl;
 		exit(1);
@@ -1172,12 +1191,12 @@ void builddNdESignal(Lkl* lkl,TString dNdEDir, Int_t nChannels,TString* channelv
 	    Float_t emax = mdm/2.*((1+mpi*mpi/(4*mdm*mdm))+(1-mpi*mpi/(4*mdm*mdm)));
 	    cout << "   * Setting dN/dE for XX->pi0gamma for mass = " << mdm  << " GeV (i.e. a line at E0=" << e0<< ", plus a box between " << emin << " and " << emax << " GeV) with BR = " << brval[iChannel] << "... " << flush;
 	    
-	    if(fullLkl->AdddNdESignalFunction("line",e0,1,brval[iChannel]))
+	    if(lkl->AdddNdESignalFunction("line",e0,1,brval[iChannel]))
 	      {
 		cout << "Failed! <---------------- FATAL ERROR!!!" << endl;
 		exit(1);
 	      }
-	    if(fullLkl->AdddNdESignalFunction("box",emin,emax,2,brval[iChannel]))
+	    if(lkl->AdddNdESignalFunction("box",emin,emax,2,brval[iChannel]))
 	      {
 		cout << "Failed! <---------------- FATAL ERROR!!!" << endl;
 		exit(1);
@@ -1196,7 +1215,7 @@ void builddNdESignal(Lkl* lkl,TString dNdEDir, Int_t nChannels,TString* channelv
 	//     Float_t emax = mdm*(1-TMath::Exp(1)/4.*me*me/(mdm*mdm));
 	//     cout << "   * Setting dN/dE for XX->ee for mass = " << mdm  << " GeV (Emax = " << emax << ") with BR = " << brval[iChannel] << "... " << flush;
 	
-	//     if(fullLkl->AdddNdESignalFunction(fee,0,emax,brval[iChannel]))
+	//     if(lkl->AdddNdESignalFunction(fee,0,emax,brval[iChannel]))
 	//       {
 	//          cout << "Failed! <---------------- FATAL ERROR!!!" << endl;
 	//          return;
@@ -1212,7 +1231,7 @@ void builddNdESignal(Lkl* lkl,TString dNdEDir, Int_t nChannels,TString* channelv
 	    cout << "   * Reading dN/dE for signal from file " << dNdESignalFileName  << " with BR = " << brval[iChannel] << "... " << flush;
 	    
 	    // Try to read dNdE from existing file
-	    if(fullLkl->AdddNdESignal(dNdESignalFileName,brval[iChannel]))
+	    if(lkl->AdddNdESignal(dNdESignalFileName,brval[iChannel]))
 	      {
 		cout << "Failed! <---------------- FATAL ERROR!!!" << endl;
 		exit(1);
@@ -1222,6 +1241,46 @@ void builddNdESignal(Lkl* lkl,TString dNdEDir, Int_t nChannels,TString* channelv
 	  }
       } // end of loop over channels
 }
+
+// Read [and write] dN/dE' for signal
+void readAndWritedNdEpSignal(Iact1dUnbinnedLkl* lkl,TString dNdEpDir,TString normchannel,Float_t mdm)
+{  
+  // build file name
+  TString dNdEpSignalFileNameForm = dNdEpDir+"dNdEpSignal_"+lkl->GetName()+"_"+normchannel+Form("_m%s",mprecform(mdm).Data())+".root";
+  TString dNdEpSignalFileName = Form(dNdEpSignalFileNameForm,mdm);
+  
+  cout << "   * Reading dN/dE' for signal from file " << dNdEpSignalFileName << "... " << flush;
+  
+  // if file does not exist, create dNdEpSignal histo (it will be saved in file later)
+  Bool_t saveHistosInFile=kFALSE;  
+  if(lkl->ReaddNdEpSignal(dNdEpSignalFileName))
+    {
+      cout << endl << "     Not found! dNdEpSignal histo will be calculated and saved in file " << dNdEpSignalFileName << endl;
+      lkl->GetdNdEpSignalIntegral(); // this calls for construction of fHdNdEpSignal out of fHdNdESignal and the energy migration matrix
+      saveHistosInFile=kTRUE;
+    }
+  // if file exists, read histo and use it
+  else
+    cout << "Ok!" << endl;	   	      
+
+  // Save the dN_signal/dE' created in the SetDMAnnihilationUnitsForG call
+  if(saveHistosInFile)
+    {
+      // saving fHdNdEpSignal histo
+      gSystem->Exec(Form("mkdir -p %s",dNdEpDir.Data()));
+      
+      TFile* dNdEpSignalFile = new TFile(dNdEpSignalFileName,"RECREATE");
+      TH1F*  hdNdEpSignal    = new TH1F(*lkl->GetHdNdEpSignal());
+      hdNdEpSignal->SetDirectory(0);
+      cout << "     Saving dN/dE' signal histo to " << dNdEpSignalFileName << "... " << flush;
+      hdNdEpSignal->Write();
+      dNdEpSignalFile->Close();
+      delete dNdEpSignalFile;
+      delete hdNdEpSignal;
+      cout << "Ok!" << endl;
+    }
+}
+
 
 TString mprecform(Double_t val)
 {

--- a/include/Iact1dBinnedLkl.h
+++ b/include/Iact1dBinnedLkl.h
@@ -42,7 +42,7 @@ class Iact1dBinnedLkl : public Iact1dUnbinnedLkl, public JointLkl
   // print data in the overview
   virtual void PrintOverview(Int_t level=0)  {Lkl::PrintOverview(level);}
   virtual void PrintData(Int_t level=0);
-  virtual Int_t  SimulateDataSamples(UInt_t seed=0,Float_t mcsv=0);
+  virtual Int_t  SimulateDataSamples(UInt_t seed=0,Float_t meanGwithUnits=0);
 
  protected:
           Int_t  InterpretInputString(TString inputString);

--- a/include/Iact1dBinnedLkl.h
+++ b/include/Iact1dBinnedLkl.h
@@ -42,7 +42,7 @@ class Iact1dBinnedLkl : public Iact1dUnbinnedLkl, public JointLkl
   // print data in the overview
   virtual void PrintOverview(Int_t level=0)  {Lkl::PrintOverview(level);}
   virtual void PrintData(Int_t level=0);
-  virtual Int_t  SimulateDataSamples(UInt_t seed=0,Float_t meanG=0);
+  virtual Int_t  SimulateDataSamples(UInt_t seed=0,Float_t mcsv=0);
 
  protected:
           Int_t  InterpretInputString(TString inputString);

--- a/include/Iact1dBinnedLkl.h
+++ b/include/Iact1dBinnedLkl.h
@@ -42,11 +42,11 @@ class Iact1dBinnedLkl : public Iact1dUnbinnedLkl, public JointLkl
   // print data in the overview
   virtual void PrintOverview(Int_t level=0)  {Lkl::PrintOverview(level);}
   virtual void PrintData(Int_t level=0);
-  virtual Int_t  SimulateDataSamples(UInt_t seed=0,Float_t meanGwithUnits=0);
+  virtual Int_t  SimulateDataSamples(Float_t meanGwithUnits=0,TRandom* rdm=NULL);
 
  protected:
           Int_t  InterpretInputString(TString inputString);
-  virtual Int_t  GetRealBkgAndGoffHistos(TRandom3* rdm,TH1F*& hdNdEpBkg,TH1F*& hdNdEpSignalOff);
+  virtual Int_t  GetRealBkgAndGoffHistos(TRandom* rdm,TH1F*& hdNdEpBkg,TH1F*& hdNdEpSignalOff);
   
   virtual void  SetFunctionAndPars(Double_t ginit=0);
   virtual Int_t MakeChecks();

--- a/include/Iact1dUnbinnedLkl.h
+++ b/include/Iact1dUnbinnedLkl.h
@@ -8,7 +8,7 @@
 #include "TH2.h"
 #include "TString.h"
 #include "TCanvas.h"
-#include "TRandom3.h"
+#include "TRandom.h"
 #include "TF1.h"
 #include "TMath.h"
 
@@ -102,19 +102,19 @@ class Iact1dUnbinnedLkl : public virtual Lkl
   Int_t TransformAndSavedNdEpFrg(TH1F* provHNOff,Bool_t interpolate=kTRUE,Double_t scale=0,Bool_t isDiff=kTRUE);
   Int_t ResetHdNdEpBkg() {if(fHdNdEpBkg) delete fHdNdEpBkg; fHdNdEpBkg=NULL; return 0;}
 
-  virtual Int_t SimulateDataSamples(UInt_t seed=0,Float_t meanGwithUnits=0);
+  virtual Int_t SimulateDataSamples(Float_t meanGwithUnits=0,TRandom* rdm=NULL);
 
   // print data in the overview
   virtual void PrintData(Int_t level=0);
   
   // Plots
-  TCanvas* PlotHistosAndData();
+  void PlotHistosAndData(TCanvas* canvas);
 
   Int_t    NormalizedNdEHisto(TH1F* histo);
 
  protected:
           Int_t    InterpretInputString(TString inputString);
-  virtual Int_t    GetRealBkgAndGoffHistos(TRandom3* rdm,TH1F*& hdNdEpBkg,TH1F*& hdNdEpSignalOff);
+  virtual Int_t    GetRealBkgAndGoffHistos(TRandom* rdm,TH1F*& hdNdEpBkg,TH1F*& hdNdEpSignalOff);
   
   virtual void     SetFunctionAndPars(Double_t ginit=0);
   virtual Int_t    MakeChecks();

--- a/include/Iact1dUnbinnedLkl.h
+++ b/include/Iact1dUnbinnedLkl.h
@@ -102,7 +102,7 @@ class Iact1dUnbinnedLkl : public virtual Lkl
   Int_t TransformAndSavedNdEpFrg(TH1F* provHNOff,Bool_t interpolate=kTRUE,Double_t scale=0,Bool_t isDiff=kTRUE);
   Int_t ResetHdNdEpBkg() {if(fHdNdEpBkg) delete fHdNdEpBkg; fHdNdEpBkg=NULL; return 0;}
 
-  virtual Int_t SimulateDataSamples(UInt_t seed=0,Float_t meanG=0);
+  virtual Int_t SimulateDataSamples(UInt_t seed=0,Float_t mcsv=0);
 
   // print data in the overview
   virtual void PrintData(Int_t level=0);

--- a/include/Iact1dUnbinnedLkl.h
+++ b/include/Iact1dUnbinnedLkl.h
@@ -102,7 +102,7 @@ class Iact1dUnbinnedLkl : public virtual Lkl
   Int_t TransformAndSavedNdEpFrg(TH1F* provHNOff,Bool_t interpolate=kTRUE,Double_t scale=0,Bool_t isDiff=kTRUE);
   Int_t ResetHdNdEpBkg() {if(fHdNdEpBkg) delete fHdNdEpBkg; fHdNdEpBkg=NULL; return 0;}
 
-  virtual Int_t SimulateDataSamples(UInt_t seed=0,Float_t mcsv=0);
+  virtual Int_t SimulateDataSamples(UInt_t seed=0,Float_t meanGwithUnits=0);
 
   // print data in the overview
   virtual void PrintData(Int_t level=0);
@@ -152,7 +152,7 @@ class Iact1dUnbinnedLkl : public virtual Lkl
   Float_t  fTau;             // Assumed normalization Noff/Non (e.g # of off regions). Equal to fDataTau except for simulations and tests
   Float_t  fDTau;            // Assumed statistical error in fTau (used for simualtions and in the likelihood). Equal to fDataDTau except for simulations and tests
   Float_t  fTrueTau;         // True value of Tau used in simulations (equal to fTau if fDTau=0, if no simulations are performed its value is 0)
-  Float_t  fObsTime;         // Assumed [s] observation time. Equal to fDataObsTime except for simulations and tests
+  Float_t  fObsTime;         // [s] assumed observation time. Equal to fDataObsTime except for simulations and tests
   Float_t  fLogJ;            // log[GeV^2 cm^-5] or log[GeV cm^2] (ann/dec respectively), log of J factor
   Bool_t   fIsOffAsOn;       // if kTRUE, use the Off event sample as Off and as On
   

--- a/include/IactEventListIrf.h
+++ b/include/IactEventListIrf.h
@@ -122,7 +122,7 @@ class IactEventListIrf : public TNamed
   TH1F*     fHdNdEpFrg   ;    //-> dN/dE'dt vs E' for foreground (gamma-events from a different source) events (normalized)
 
 
-  ClassDef(IactEventListIrf,1) // Class to hold the data and IRFs from IACTs to be used as input by Iact1dUnbinnedLkl class
+  ClassDef(IactEventListIrf,2) // Class to hold the data and IRFs from IACTs to be used as input by Iact1dUnbinnedLkl class
 };
 
 #endif

--- a/rcfiles/jointLklDM.rc
+++ b/rcfiles/jointLklDM.rc
@@ -62,11 +62,11 @@ jointLklDM.Process: ann
 # list of DM masses to be considered (in GeV)
 jointLklDM.MassList: 100 200 500 1000 2000 5000 10000 20000 50000 100000
 
-# Mean g (number of signal events) for simulations
-# this should be replaced in future release by <sv>
-# but the problem is that <sv> depends on the channel and mass through:
-# g = <sv>*J/(8*Pi*m^2) * integral between fEpmin and fEpmax of fHdNdEpSignal
-jointLklDM.mcG: 0
+# <sv> true value assumed for simulations in units of cm^3/s
+# If it is different from 0, an independent simualted observation will be generated for each mass
+# For each mass and sample, g signal events will be generated with g = <sv>/fUnitsOfG
+# (recall that fUnitsOfG depends on the mass, observation time and dN/dE')
+jointLklDM.mcsv: 0
 
 # If TRUE (FALSE) g is restricted to positive values only (i.e. Fermi prescription for lkl maximizing out of the physical region)
 jointLklDM.isGpositive: TRUE

--- a/rcfiles/jointLklDM.rc
+++ b/rcfiles/jointLklDM.rc
@@ -63,12 +63,12 @@ jointLklDM.Channel: bb
 jointLklDM.MassList: 100 200 500 1000 2000 5000 10000 20000 50000 100000
 
 # Simulated signal data characteristics (i.e. true values assumed for simulations, no to be confused with the values assumed for the likelihood function
-# <sv> [cm^3/s], if > 0 then simulations will be produced and eventually orverride the real data
+# alpha = <sv> [cm^3/s] for ann or 1/tau [1/s] for dec
 # DM mass [GeV]
 # process ("ann" or "dec" for annhilation and decay, respectively, default is annihilation)
 # channel (bb, cc, tt, tautau, mumu, WW, ZZ, hh, gammagamma, pi0pi0, pi0gamma, ee, branon or an arbitrary linear combination of them)
-jointLklDM.mcsv: 0
-jointLklDM.mcmass: 1000
+jointLklDM.mcalpha: 0
+jointLklDM.mcMass: 1000
 jointLklDM.mcProcess: ann
 jointLklDM.mcChannel: bb
 

--- a/rcfiles/jointLklDM.rc
+++ b/rcfiles/jointLklDM.rc
@@ -51,22 +51,26 @@ jointLklDM.plotsDir: plots
 ANALYSIS CONFIGURATION
 ######################
 
-# channel to be analyzed (bb, cc, tt, tautau, mumu, WW, ZZ, hh, gammagamma, pi0pi0, pi0gamma, ee, nutaunutau, numunumu, nuenue, VV-4tau, VV-4mu, VV-4e, branon or an arbitrary linear combination of them)
-# The linear combination must be written this form:'br_1*channel_1+...+br_n*channel_n'!
-jointLklDM.Channel: bb
-
 # Process to be analyzed ("ann" or "dec" for annhilation and decay, respectively, default is annihilation
 # (remember to change consistently the list of masses and J-factor value and uncertainty)
 jointLklDM.Process: ann
 
+# channel to be analyzed (bb, cc, tt, tautau, mumu, WW, ZZ, hh, gammagamma, pi0pi0, pi0gamma, ee, nutaunutau, numunumu, nuenue, VV-4tau, VV-4mu, VV-4e, branon or an arbitrary linear combination of them)
+# The linear combination must be written this form:'br_1*channel_1+...+br_n*channel_n'!
+jointLklDM.Channel: bb
+
 # list of DM masses to be considered (in GeV)
 jointLklDM.MassList: 100 200 500 1000 2000 5000 10000 20000 50000 100000
 
-# <sv> true value assumed for simulations in units of cm^3/s
-# If it is different from 0, an independent simualted observation will be generated for each mass
-# For each mass and sample, g signal events will be generated with g = <sv>/fUnitsOfG
-# (recall that fUnitsOfG depends on the mass, observation time and dN/dE')
+# Simulated signal data characteristics (i.e. true values assumed for simulations, no to be confused with the values assumed for the likelihood function
+# <sv> [cm^3/s], if > 0 then simulations will be produced and eventually orverride the real data
+# DM mass [GeV]
+# process ("ann" or "dec" for annhilation and decay, respectively, default is annihilation)
+# channel (bb, cc, tt, tautau, mumu, WW, ZZ, hh, gammagamma, pi0pi0, pi0gamma, ee, branon or an arbitrary linear combination of them)
 jointLklDM.mcsv: 0
+jointLklDM.mcmass: 1000
+jointLklDM.mcProcess: ann
+jointLklDM.mcChannel: bb
 
 # If TRUE (FALSE) g is restricted to positive values only (i.e. Fermi prescription for lkl maximizing out of the physical region)
 jointLklDM.isGpositive: TRUE

--- a/scripts/jointLklDM.C
+++ b/scripts/jointLklDM.C
@@ -90,6 +90,8 @@ void setDefaultStyle();
 void decode_channel(TObjArray* coefficients, Int_t &nChannels, TString *channelval, Double_t *brval);
 void compute_branonBR(Float_t &mass, Int_t &nChannels, TString *channelval, Double_t *brval, Double_t &translation_factor);
 Int_t GetNSkippedMasses(Int_t nm,const Double_t* vm,Double_t minm);
+void builddNdESignal(Lkl* lkl,TString dNdEDir, Int_t nChannels,TString* channelval,Double_t* brval,Float_t mdm,Bool_t isDecay,Bool_t isSimulation);
+TString mprecform(Double_t val);
 
 const Int_t nMaxLkls = 1000;
 
@@ -136,7 +138,10 @@ void jointLklDM(TString configFileName="$GLIKESYS/rcfiles/jointLklDM.rc",Int_t s
   TString  fPlotsDir         = fInputDataPath+"/"+env->GetValue("jointLklDM.plotsDir","")+"/";
   TString  provval           = env->GetValue("jointLklDM.dNdEpSignalDir","-");
   TString  fdNdEpSignalDir   = fInputDataPath+"/"+provval+"/";
-  Float_t  mcG               = env->GetValue("jointLklDM.mcG",0.);  //assumed value of <sv> for simulations
+  Float_t  mcsv              = env->GetValue("jointLklDM.mcsv",0.);    // value of <sv> assumed for simulations
+  Float_t  mcmass            = env->GetValue("jointLklDM.mcmass",0.);  // value of DM mass assumed for simulations
+  TString  mcChannel         = env->GetValue("jointLklDM.mcChannel","bb");
+  TString  mcProcess         = env->GetValue("jointLklDM.mcProcess","ann");
   TString  massList          = env->GetValue("jointLklDM.MassList","");
   Bool_t   exportData        = env->GetValue("jointLklDM.exportData",kFALSE);
   Double_t svMin             = env->GetValue("jointLklDM.exportSvMin",0.);
@@ -234,7 +239,11 @@ void jointLklDM(TString configFileName="$GLIKESYS/rcfiles/jointLklDM.rc",Int_t s
   cout << " ** Channel check            : " << normchannel << endl;
   cout << "*** DATA/MC                  : " << simulationlabel << endl;
   if(isSimulation)
-    cout << " ** Seed                     : " << seed << endl;
+    {
+      cout << " ** Seed                     : " << seed << endl;
+      cout << " ** <sv>_MC                  : " << mcsv << " cm^3/s" << endl;
+      cout << " ** m_MC                     : " << mcmass << " GeV" << endl;
+    }
   cout << "*** G IS POSITIVE            : " << (isGpositive? "YES" : "NO") << endl;
       
   // how many and which mass values are we considering?
@@ -313,11 +322,12 @@ void jointLklDM(TString configFileName="$GLIKESYS/rcfiles/jointLklDM.rc",Int_t s
 
 	  // save as sample (as opposed to JointLkl)
 	  sample[nsamples++] = lkl[iLkl];
-	  	  
-	  // if it's simulation, simulate the data sample
-	  if(isSimulation)
+
+          // if it's simulation of the null hypothesis, we can already simulate the data sample
+          if(isSimulation && mcsv==0)
 	    {
-	      if(dynamic_cast<Iact1dUnbinnedLkl*>(lkl[iLkl])->SimulateDataSamples(seed,mcG))
+              cout << "  * Simulating observations for <sv> = " << mcsv << endl;
+	      if(dynamic_cast<Iact1dUnbinnedLkl*>(lkl[iLkl])->SimulateDataSamples(seed,mcsv))
 		{
 		  cout << " ## Oops! Cannot simulate samples for " << lkl[iLkl]->GetName() << " <---------------- FATAL ERROR!!!"<< endl;
 		  return;
@@ -341,10 +351,11 @@ void jointLklDM(TString configFileName="$GLIKESYS/rcfiles/jointLklDM.rc",Int_t s
 	  // configure
 	  lkl[iLkl]->SetName(Form("Iact1dBinnedLkl_%02d",iLkl));	  
 
-	  // if it's simulation, simulate the data sample
-	  if(isSimulation)
+          // if it's simulation of the null hypothesis, we can already simulate the data sample
+          if(isSimulation && mcsv==0)
 	    {
-	      if(dynamic_cast<Iact1dBinnedLkl*>(lkl[iLkl])->SimulateDataSamples(seed,mcG))
+              cout << "  * Simulating observations for <sv> = " << mcsv << endl;
+	      if(dynamic_cast<Iact1dBinnedLkl*>(lkl[iLkl])->SimulateDataSamples(seed,mcsv))
 		{
 		  cout << " ## Oops! Cannot simulate samples for " << lkl[iLkl]->GetName() << " <---------------- FATAL ERROR!!!"<< endl;
 		  return;
@@ -569,127 +580,25 @@ void jointLklDM(TString configFileName="$GLIKESYS/rcfiles/jointLklDM.rc",Int_t s
           cout << "**** Translation factor for the tension of the brane: " << braneTensionVal[imass] << endl;
         }
 
-      // compute the minimum precision the mass needs to be reported with
-      Int_t mprec;
-      for(mprec=10;mprec>=0;mprec--)
-	if(mass<TMath::Power(10,-mprec))
-	  break;
-      TString mprecform = Form("%%.%df",mprec+2);
-
       // Loop over samples to read the dN/dE and dN/dE' histos for signal from files
       ///////////////////////////////////////////////////////////////////////////////////////////////
       Bool_t saveHistosInFile=kFALSE;
-      cout << " *** Reading dN/dE histos for signal and read or compute dN/dE' histos for each samples:" << endl;
+      cout << " *** Read or compute dN/dE and dN/dE' histos for each samples:" << endl;
       for(Int_t isample=0;isample<nLkls;isample++)
         {
 	  if(!strcmp(lkl[isample]->ClassName(),"Iact1dUnbinnedLkl") || !strcmp(lkl[isample]->ClassName(),"Iact1dBinnedLkl"))
 	    {
-	      // casted pointer (for less messy code)
+	      builddNdESignal(lkl[isample],fdNdEDir,nChannels,channelval,brval,mdm,isDecay,isSimulation);
+
+	      // Read or create dN/dE' for signal
 	      Iact1dUnbinnedLkl* fullLkl = NULL;
 	      if(!strcmp(lkl[isample]->ClassName(),"Iact1dUnbinnedLkl")) fullLkl = dynamic_cast<Iact1dUnbinnedLkl*>(lkl[isample]);
 	      if(!strcmp(lkl[isample]->ClassName(),"Iact1dBinnedLkl"))   fullLkl = dynamic_cast<Iact1dBinnedLkl*>(lkl[isample]);
-	      
-	      
-	      cout << "  ** Reading histos for sample " << fullLkl->GetName() << ":" << endl;
-	      // Delete existing fHdNdESignal and create empty one
-	      fullLkl->ResetdNdESignal();
-	      
-	      for(Int_t iChannel=0;iChannel<nChannels;iChannel++)
-		{
-		  // Read dN/dE for signal from file (try if it exists)
-		  if(brval[iChannel] != 0.0)
-		    {
-		      if(!channelval[iChannel].CompareTo("gammagamma",TString::kIgnoreCase))
-			{
-			  cout << "   * Setting dN/dE for a monochromatic line at energy " << mdm  << " GeV with BR = " << brval[iChannel] << " ... " << flush;
-			  if(fullLkl->AdddNdESignalFunction("line",mdm,2,brval[iChannel]))
-			    {
-			      cout << "Failed! <---------------- FATAL ERROR!!!" << endl;
-			      return;
-			    }
-			  else
-			    cout << "Ok!" << endl;
-			}
-		      else if(!channelval[iChannel].CompareTo("pi0pi0",TString::kIgnoreCase))
-			{
-			  const Float_t mpi = 0.135; // pi0 mass in GeV
-			  Float_t emin =  mdm/2.*(1-TMath::Sqrt(1-mpi*mpi/(mdm*mdm)));
-			  Float_t emax =  mdm/2.*(1+TMath::Sqrt(1-mpi*mpi/(mdm*mdm)));
-			  cout << "   * Setting dN/dE for XX->pi0pi0 for mass = " << mdm  << " GeV (i.e. box between " << emin << " and " << emax << " GeV) with BR = " << brval[iChannel] << "... " << flush;
-			  
-			  if(fullLkl->AdddNdESignalFunction("box",emin,emax,4,brval[iChannel]))
-			    {
-			      cout << "Failed! <---------------- FATAL ERROR!!!" << endl;
-			      return;
-			    }
-			  else
-			    cout << "Ok!" << endl;
-			}
-		      else if(!channelval[iChannel].CompareTo("pi0gamma",TString::kIgnoreCase) || !channelval[iChannel].CompareTo("gammapi0",TString::kIgnoreCase))
-			{
-			  const Float_t mpi = 0.135; // pi0 mass in GeV
-			  Float_t e0   = mdm-mpi*mpi/(4*mdm);
-			  Float_t emin = mdm/2.*((1+mpi*mpi/(4*mdm*mdm))-(1-mpi*mpi/(4*mdm*mdm)));
-			  Float_t emax = mdm/2.*((1+mpi*mpi/(4*mdm*mdm))+(1-mpi*mpi/(4*mdm*mdm)));
-			  cout << "   * Setting dN/dE for XX->pi0gamma for mass = " << mdm  << " GeV (i.e. a line at E0=" << e0<< ", plus a box between " << emin << " and " << emax << " GeV) with BR = " << brval[iChannel] << "... " << flush;
-			  
-			  if(fullLkl->AdddNdESignalFunction("line",e0,1,brval[iChannel]))
-			    {
-			      cout << "Failed! <---------------- FATAL ERROR!!!" << endl;
-			      return;
-			    }
-			  if(fullLkl->AdddNdESignalFunction("box",emin,emax,2,brval[iChannel]))
-			    {
-			      cout << "Failed! <---------------- FATAL ERROR!!!" << endl;
-			      return;
-			    }
-			  else
-			    cout << "Ok!" << endl;
-			}
-		      // commented out because we read it from histograms like the rest of the usual channels
-		      // else if(!channelval[iChannel].CompareTo("ee",TString::kIgnoreCase))
-		      //   {
-		      //     const Float_t me = 0.511e-3; // e mass in GeV
-		      
-		      //     TF1* fee = new TF1("fee","1./137./TMath::Pi()/x*(TMath::Log(4*[0]*([0]-x)/([1]*[1]))-1)*(1+TMath::Power(4*[0]*([0]-x)/(4*[0]*[0]),2))",1e-4,mdm);
-		      //     fee->SetParameter(0,mdm);
-		      //     fee->SetParameter(1,me);
-		      //     Float_t emax = mdm*(1-TMath::Exp(1)/4.*me*me/(mdm*mdm));
-		      //     cout << "   * Setting dN/dE for XX->ee for mass = " << mdm  << " GeV (Emax = " << emax << ") with BR = " << brval[iChannel] << "... " << flush;
-		      
-		      //     if(fullLkl->AdddNdESignalFunction(fee,0,emax,brval[iChannel]))
-		      //       {
-		      //          cout << "Failed! <---------------- FATAL ERROR!!!" << endl;
-		      //          return;
-		      //       }
-		      //     else
-		      //       cout << "Ok!" << endl;
-		      //     delete fee;
-		      //   }
-		      else
-			{
-			  TString dNdESignalFileNameForm   = fdNdEDir+"dNdESignal_"+channelval[iChannel]+Form("_%smass.root",mprecform.Data());
-			  const TString dNdESignalFileName = Form(dNdESignalFileNameForm,(isDecay? mass/2. : mass));
-			  cout << "   * Reading dN/dE for signal from file " << dNdESignalFileName  << " with BR = " << brval[iChannel] << "... " << flush;
-			  
-			  // Try to read dNdE from existing file
-			  if(fullLkl->AdddNdESignal(dNdESignalFileName,brval[iChannel]))
-			    {
-			      cout << "Failed! <---------------- FATAL ERROR!!!" << endl;
-			      return;
-			    }
-			  else
-			    cout << "Ok!" << endl;
-			}
-		    }
-		}
-	      
-	      // Read or create dN/dE' for signal
 	      TString dNdEpSignalFileName;
 	      if(ioHdNdEpSignal)
 		{
-		  TString dNdEpSignalFileNameForm = fdNdEpSignalDir+"dNdEpSignal_"+fullLkl->GetName()+"_"+normchannel+Form("_m%s",mprecform.Data())+".root";
-		  dNdEpSignalFileName = Form(dNdEpSignalFileNameForm,(isDecay? mass/2. : mass));
+		  TString dNdEpSignalFileNameForm = fdNdEpSignalDir+"dNdEpSignal_"+fullLkl->GetName()+"_"+normchannel+Form("_m%s",mprecform(mdm).Data())+".root";
+		  dNdEpSignalFileName = Form(dNdEpSignalFileNameForm,mdm);
 		  cout << "   * Reading dN/dE' for signal from file " << dNdEpSignalFileName << "... " << flush;
 		  
 		  
@@ -709,7 +618,19 @@ void jointLklDM(TString configFileName="$GLIKESYS/rcfiles/jointLklDM.rc",Int_t s
 	        fullLkl->SetDMDecayUnitsForG(mass);
 	      else	      
 	        fullLkl->SetDMAnnihilationUnitsForG(mass);
-	      
+
+              // in case simulations were requested with DM cont, do them now
+	      if(isSimulation && mcsv>0 && mcmass>0)
+		{
+		  cout << "  * Simulating observations for <sv> = " << mcsv << " and m_DM = " << mcmass << endl;
+
+		  if(fullLkl->SimulateDataSamples(seed,mcsv))
+		    {
+		      cout << " ## Oops! Cannot simulate samples for " << fullLkl->GetName() << " <---------------- FATAL ERROR!!!"<< endl;
+		      exit(1);
+		    }
+		}
+
 	      // Save the dN_signal/dE' created in the SetDMAnnihilationUnitsForG call
 	      if(ioHdNdEpSignal && saveHistosInFile)
 	        {
@@ -848,7 +769,7 @@ void jointLklDM(TString configFileName="$GLIKESYS/rcfiles/jointLklDM.rc",Int_t s
 	    }
 	  lklcanvas->cd(imass+1);
 
-	  TString parabolaplotform = Form("-2logLkl vs %s for mass %s GeV",(isDecay? "1/#tau_{DM}":"<sv>"),mprecform.Data());
+	  TString parabolaplotform = Form("-2logLkl vs %s for mass %s GeV",(isDecay? "1/#tau_{DM}":"<sv>"),mprecform(mass).Data());
 	  
 	  // plot empty histo with nice settings to hold the -2logLkl parabolas
 	  TString dummytit = Form(parabolaplotform,mass);
@@ -1275,3 +1196,114 @@ void compute_branonBR(Float_t &mass, Int_t &nChannels, TString *channelval, Doub
     // Computation of the translation factor for the tension of the brane
     translation_factor = total_ann_crosssection;
   }
+
+void builddNdESignal(Lkl* lkl,TString dNdEDir, Int_t nChannels,TString* channelval,Double_t* brval,Float_t mdm,Bool_t isDecay,Bool_t isSimulation)
+{
+  // casted pointer (for less messy code)
+  Iact1dUnbinnedLkl* fullLkl = NULL;
+  if(!strcmp(lkl->ClassName(),"Iact1dUnbinnedLkl")) fullLkl = dynamic_cast<Iact1dUnbinnedLkl*>(lkl);
+  if(!strcmp(lkl->ClassName(),"Iact1dBinnedLkl"))   fullLkl = dynamic_cast<Iact1dBinnedLkl*>(lkl);
+
+  cout << "  ** Building histos for sample " << fullLkl->GetName() << ":" << endl;
+
+  // Delete existing fHdNdESignal and create empty one
+  fullLkl->ResetdNdESignal();
+
+  for(Int_t iChannel=0;iChannel<nChannels;iChannel++)
+    if(brval[iChannel] != 0.0)
+      {
+	// first check if channel associated dN/dE can be represented by a simple formula
+	if(!channelval[iChannel].CompareTo("gammagamma",TString::kIgnoreCase))
+	  {
+	    cout << "   * Setting dN/dE for a monochromatic line at energy " << mdm  << " GeV with BR = " << brval[iChannel] << " ... " << flush;
+	    if(fullLkl->AdddNdESignalFunction("line",mdm,2,brval[iChannel]))
+	      {
+		cout << "Failed! <---------------- FATAL ERROR!!!" << endl;
+		exit(1);
+	      }
+	    else
+	      cout << "Ok!" << endl;
+	  }
+	else if(!channelval[iChannel].CompareTo("pi0pi0",TString::kIgnoreCase))
+	  {
+	    const Float_t mpi = 0.135; // pi0 mass in GeV
+	    Float_t emin =  mdm/2.*(1-TMath::Sqrt(1-mpi*mpi/(mdm*mdm)));
+	    Float_t emax =  mdm/2.*(1+TMath::Sqrt(1-mpi*mpi/(mdm*mdm)));
+	    cout << "   * Setting dN/dE for XX->pi0pi0 for mass = " << mdm  << " GeV (i.e. box between " << emin << " and " << emax << " GeV) with BR = " << brval[iChannel] << "... " << flush;
+
+	    if(fullLkl->AdddNdESignalFunction("box",emin,emax,4,brval[iChannel]))
+	      {
+		cout << "Failed! <---------------- FATAL ERROR!!!" << endl;
+		exit(1);
+	      }
+	    else
+	      cout << "Ok!" << endl;
+	  }
+	else if(!channelval[iChannel].CompareTo("pi0gamma",TString::kIgnoreCase) || !channelval[iChannel].CompareTo("gammapi0",TString::kIgnoreCase))
+	  {
+	    const Float_t mpi = 0.135; // pi0 mass in GeV
+	    Float_t e0   = mdm-mpi*mpi/(4*mdm);
+	    Float_t emin = mdm/2.*((1+mpi*mpi/(4*mdm*mdm))-(1-mpi*mpi/(4*mdm*mdm)));
+	    Float_t emax = mdm/2.*((1+mpi*mpi/(4*mdm*mdm))+(1-mpi*mpi/(4*mdm*mdm)));
+	    cout << "   * Setting dN/dE for XX->pi0gamma for mass = " << mdm  << " GeV (i.e. a line at E0=" << e0<< ", plus a box between " << emin << " and " << emax << " GeV) with BR = " << brval[iChannel] << "... " << flush;
+
+	    if(fullLkl->AdddNdESignalFunction("line",e0,1,brval[iChannel]))
+	      {
+		cout << "Failed! <---------------- FATAL ERROR!!!" << endl;
+		exit(1);
+	      }
+	    if(fullLkl->AdddNdESignalFunction("box",emin,emax,2,brval[iChannel]))
+	      {
+		cout << "Failed! <---------------- FATAL ERROR!!!" << endl;
+		exit(1);
+	      }
+	    else
+	      cout << "Ok!" << endl;
+	  }
+	// commented out because we read it from histograms like the rest of the usual channels
+	// else if(!channelval[iChannel].CompareTo("ee",TString::kIgnoreCase))
+	//   {
+	//     const Float_t me = 0.511e-3; // e mass in GeV
+
+	//     TF1* fee = new TF1("fee","1./137./TMath::Pi()/x*(TMath::Log(4*[0]*([0]-x)/([1]*[1]))-1)*(1+TMath::Power(4*[0]*([0]-x)/(4*[0]*[0]),2))",1e-4,mdm);
+	//     fee->SetParameter(0,mdm);
+	//     fee->SetParameter(1,me);
+	//     Float_t emax = mdm*(1-TMath::Exp(1)/4.*me*me/(mdm*mdm));
+	//     cout << "   * Setting dN/dE for XX->ee for mass = " << mdm  << " GeV (Emax = " << emax << ") with BR = " << brval[iChannel] << "... " << flush;
+
+	//     if(fullLkl->AdddNdESignalFunction(fee,0,emax,brval[iChannel]))
+	//       {
+	//          cout << "Failed! <---------------- FATAL ERROR!!!" << endl;
+	//          return;
+	//       }
+	//     else
+	//       cout << "Ok!" << endl;
+	//     delete fee;
+	//   }
+	else
+	  {
+	    TString dNdESignalFileNameForm   = dNdEDir+"dNdESignal_"+channelval[iChannel]+Form("_%smass.root",mprecform(mdm).Data());
+	    const TString dNdESignalFileName = Form(dNdESignalFileNameForm,mdm);
+	    cout << "   * Reading dN/dE for signal from file " << dNdESignalFileName  << " with BR = " << brval[iChannel] << "... " << flush;
+
+	    // Try to read dNdE from existing file
+	    if(fullLkl->AdddNdESignal(dNdESignalFileName,brval[iChannel]))
+	      {
+		cout << "Failed! <---------------- FATAL ERROR!!!" << endl;
+		exit(1);
+	      }
+	    else
+	      cout << "Ok!" << endl;
+	  }
+      } // end of loop over channels
+}
+
+TString mprecform(Double_t val)
+{
+  // compute the minimum precision the value (e.g. mass) needs to be reported with
+  Int_t mprec;
+  for(mprec=10;mprec>=0;mprec--)
+    if(val<TMath::Power(10,-mprec))
+      break;
+  return Form("%%.%df",mprec+2);
+}

--- a/src/Iact1dBinnedLkl.cc
+++ b/src/Iact1dBinnedLkl.cc
@@ -657,7 +657,7 @@ TH1F* Iact1dBinnedLkl::GetHdNdEpOff(Bool_t isDifferential,Int_t nbins) const
 // Returns: 0 in case of success
 //          1 otherwise
 //
-Int_t Iact1dBinnedLkl::SimulateDataSamples(UInt_t seed,Float_t mcsv)
+Int_t Iact1dBinnedLkl::SimulateDataSamples(UInt_t seed,Float_t meanGwithUnits)
 {
   // basic check
   if(fTauEDepFluct && !fdNdEpBkgFromOff)
@@ -686,7 +686,7 @@ Int_t Iact1dBinnedLkl::SimulateDataSamples(UInt_t seed,Float_t mcsv)
   if(fHNOff) delete fHNOff;
   fHNOn = fHNOff = NULL;
   
-  return Iact1dUnbinnedLkl::SimulateDataSamples(seed,mcsv);
+  return Iact1dUnbinnedLkl::SimulateDataSamples(seed,meanGwithUnits);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/Iact1dBinnedLkl.cc
+++ b/src/Iact1dBinnedLkl.cc
@@ -650,14 +650,14 @@ TH1F* Iact1dBinnedLkl::GetHdNdEpOff(Bool_t isDifferential,Int_t nbins) const
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // 
 // Simulate list of On and Off events
-// If no background model has been provided, the use the distribution
+// If no background model has been provided, we use the distribution
 // of Off events as model
 // see also Iact1dUnbinnedLkl::SimulateDataSamples for more details
 //
 // Returns: 0 in case of success
 //          1 otherwise
 //
-Int_t Iact1dBinnedLkl::SimulateDataSamples(UInt_t seed,Float_t meanG)
+Int_t Iact1dBinnedLkl::SimulateDataSamples(UInt_t seed,Float_t mcsv)
 {
   // basic check
   if(fTauEDepFluct && !fdNdEpBkgFromOff)
@@ -686,7 +686,7 @@ Int_t Iact1dBinnedLkl::SimulateDataSamples(UInt_t seed,Float_t meanG)
   if(fHNOff) delete fHNOff;
   fHNOn = fHNOff = NULL;
   
-  return Iact1dUnbinnedLkl::SimulateDataSamples(seed,meanG);
+  return Iact1dUnbinnedLkl::SimulateDataSamples(seed,mcsv);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/Iact1dBinnedLkl.cc
+++ b/src/Iact1dBinnedLkl.cc
@@ -249,33 +249,6 @@ Int_t Iact1dBinnedLkl::MakeChecks()
       cout << "Iact1dBinnedLkl::MakeChecks (" << GetName() << ") Warning: missing information, cannot perform fit, check your code!" << endl;
       return 1;
     }
-
-  // normalize unnormalized histos
-  if(GetdNdEpSignalIntegral()<=0)
-    {
-      cout << "Iact1dBinnedLkl::MakeChecks (" << GetName() << ") Warning: fHdNdEpSignal is not normalized!" << endl;
-      return 1;
-    }
-  
-  if(GetHdNdEpSignalOff())
-    if(GetdNdEpSignalOffIntegral()<=0)
-      {
-	cout << "Iact1dBinnedLkl::MakeChecks (" << GetName() << ") Warning: fHdNdEpSignalOff is not normalized!" << endl;
-	return 1;
-      }
-  
-  if(GetdNdESignalIntegral()<=0) 
-    {
-      cout << "Iact1dBinnedLkl::MakeChecks (" << GetName() << ") Warning: fHdNdESignal is not normalized!" << endl;
-      return 1;
-    }
-
-  if(GetHdNdEpFrg())
-    if(GetdNdEpFrgIntegral()<=0) 
-      {
-	cout << "Iact1dBinnedLkl::MakeChecks (" << GetName() << ") Warning: fHdNdEpFrg is not normalized!" << endl;
-	return 1;
-      }
   
   // Check the Iact1dBinnedLkl specific part
   /////////////////////////////////////////
@@ -657,7 +630,7 @@ TH1F* Iact1dBinnedLkl::GetHdNdEpOff(Bool_t isDifferential,Int_t nbins) const
 // Returns: 0 in case of success
 //          1 otherwise
 //
-Int_t Iact1dBinnedLkl::SimulateDataSamples(UInt_t seed,Float_t meanGwithUnits)
+Int_t Iact1dBinnedLkl::SimulateDataSamples(Float_t meanGwithUnits,TRandom* rdm)
 {
   // basic check
   if(fTauEDepFluct && !fdNdEpBkgFromOff)
@@ -686,7 +659,7 @@ Int_t Iact1dBinnedLkl::SimulateDataSamples(UInt_t seed,Float_t meanGwithUnits)
   if(fHNOff) delete fHNOff;
   fHNOn = fHNOff = NULL;
   
-  return Iact1dUnbinnedLkl::SimulateDataSamples(seed,meanGwithUnits);
+  return Iact1dUnbinnedLkl::SimulateDataSamples(meanGwithUnits,rdm);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -697,7 +670,7 @@ Int_t Iact1dBinnedLkl::SimulateDataSamples(UInt_t seed,Float_t meanGwithUnits)
 // and fHdNdEpSignalOff the expected distribution of signal events in the total Off region
 // (total meaning that if tau=3 the effective area to consder is that of the three subregions)
 //
-Int_t Iact1dBinnedLkl::GetRealBkgAndGoffHistos(TRandom3* rdm,TH1F*& hdNdEpBkg,TH1F*& hdNdEpSignalOff) 
+Int_t Iact1dBinnedLkl::GetRealBkgAndGoffHistos(TRandom* rdm,TH1F*& hdNdEpBkg,TH1F*& hdNdEpSignalOff) 
 {
   // if fHdNdBkg was provided as input, use global normalization
   if(!fdNdEpBkgFromOff) return Iact1dUnbinnedLkl::GetRealBkgAndGoffHistos(rdm,hdNdEpBkg,hdNdEpSignalOff);

--- a/src/Iact1dUnbinnedLkl.cc
+++ b/src/Iact1dUnbinnedLkl.cc
@@ -1261,18 +1261,18 @@ Int_t Iact1dUnbinnedLkl::SetMigMatrix(TH2F* provMM)
 // according to the total pdf described by fHdNdEpBkg and fHdNdEpSignal
 // and the observation time in fObsTime and tau taking randomly from a
 // gaussian of mean fTau and mean fDTau
-// seed    (default 0) = seed for random generator
-// mcsv    (default 0) = assumed <sv> value [cm3 s-1]
+// seed           (default 0) = seed for random generator
+// meanGwithUnits (default 0) = assumed value of g (in units of fUnitsOfG)
 //
-// IF meanG<0, do not simulate independent ON events, use OFF sample
+// IF meanGwithUnits<0, do not simulate independent ON events, use OFF sample
 // also as ON
 //
 // Return 0 in case of success
 //        1 otherwise
 //
-Int_t Iact1dUnbinnedLkl::SimulateDataSamples(UInt_t seed,Float_t mcsv)
+Int_t Iact1dUnbinnedLkl::SimulateDataSamples(UInt_t seed,Float_t meanGwithUnits)
 {
-  if(mcsv<0) mcsv=0;
+  if(meanGwithUnits<0) meanGwithUnits=0;
   
   // Sanity checks
   if(!fHdNdEpBkg)
@@ -1280,7 +1280,7 @@ Int_t Iact1dUnbinnedLkl::SimulateDataSamples(UInt_t seed,Float_t mcsv)
       cout << endl << "Iact1dUnbinnedLkl::SimulateDataSamples Error: fHdNdEpBkg missing, cannot simulate events" << endl;
       return 1;
     }
-  if(mcsv>0 && !fHdNdEpSignal)
+  if(meanGwithUnits>0 && !fHdNdEpSignal)
     {
       cout << endl << "Iact1dUnbinnedLkl::SimulateDataSamples Error: you want to simulate signal events but fHdNdEpSignal is missing, cannot simulate events" << endl;
       return 1;
@@ -1302,7 +1302,7 @@ Int_t Iact1dUnbinnedLkl::SimulateDataSamples(UInt_t seed,Float_t mcsv)
   if(GetRealBkgAndGoffHistos(rdm,realHdNdEpBkg,realHdNdEpSignalOff)) return 1;
 
 
-  Float_t meanG    = mcsv/GetUnitsOfG();
+  Float_t meanG    = meanGwithUnits/GetUnitsOfG();   // remove units to copute expected number of signal events
   Float_t meanB    = GetdNdEpBkgIntegral()*fObsTime;  
   Float_t meanBoff = realHdNdEpBkg->GetBinContent(0)*fObsTime*fTau;
   Float_t meanF    = GetdNdEpFrgIntegral()*fObsTime;

--- a/src/Iact1dUnbinnedLkl.cc
+++ b/src/Iact1dUnbinnedLkl.cc
@@ -1302,7 +1302,7 @@ Int_t Iact1dUnbinnedLkl::SimulateDataSamples(UInt_t seed,Float_t meanGwithUnits)
   if(GetRealBkgAndGoffHistos(rdm,realHdNdEpBkg,realHdNdEpSignalOff)) return 1;
 
 
-  Float_t meanG    = meanGwithUnits/GetUnitsOfG();   // remove units to copute expected number of signal events
+  Float_t meanG    = meanGwithUnits/GetUnitsOfG();   // remove units to compute expected number of signal events
   Float_t meanB    = GetdNdEpBkgIntegral()*fObsTime;  
   Float_t meanBoff = realHdNdEpBkg->GetBinContent(0)*fObsTime*fTau;
   Float_t meanF    = GetdNdEpFrgIntegral()*fObsTime;

--- a/src/Iact1dUnbinnedLkl.cc
+++ b/src/Iact1dUnbinnedLkl.cc
@@ -1262,7 +1262,7 @@ Int_t Iact1dUnbinnedLkl::SetMigMatrix(TH2F* provMM)
 // and the observation time in fObsTime and tau taking randomly from a
 // gaussian of mean fTau and mean fDTau
 // seed    (default 0) = seed for random generator
-// meanG   (default 0) = mean G value
+// mcsv    (default 0) = assumed <sv> value [cm3 s-1]
 //
 // IF meanG<0, do not simulate independent ON events, use OFF sample
 // also as ON
@@ -1270,9 +1270,9 @@ Int_t Iact1dUnbinnedLkl::SetMigMatrix(TH2F* provMM)
 // Return 0 in case of success
 //        1 otherwise
 //
-Int_t Iact1dUnbinnedLkl::SimulateDataSamples(UInt_t seed,Float_t meanG)
+Int_t Iact1dUnbinnedLkl::SimulateDataSamples(UInt_t seed,Float_t mcsv)
 {
-  if(meanG<0) meanG=0;
+  if(mcsv<0) mcsv=0;
   
   // Sanity checks
   if(!fHdNdEpBkg)
@@ -1280,7 +1280,7 @@ Int_t Iact1dUnbinnedLkl::SimulateDataSamples(UInt_t seed,Float_t meanG)
       cout << endl << "Iact1dUnbinnedLkl::SimulateDataSamples Error: fHdNdEpBkg missing, cannot simulate events" << endl;
       return 1;
     }
-  if(meanG>0 && !fHdNdEpSignal)
+  if(mcsv>0 && !fHdNdEpSignal)
     {
       cout << endl << "Iact1dUnbinnedLkl::SimulateDataSamples Error: you want to simulate signal events but fHdNdEpSignal is missing, cannot simulate events" << endl;
       return 1;
@@ -1301,6 +1301,8 @@ Int_t Iact1dUnbinnedLkl::SimulateDataSamples(UInt_t seed,Float_t meanG)
 
   if(GetRealBkgAndGoffHistos(rdm,realHdNdEpBkg,realHdNdEpSignalOff)) return 1;
 
+
+  Float_t meanG    = mcsv/GetUnitsOfG();
   Float_t meanB    = GetdNdEpBkgIntegral()*fObsTime;  
   Float_t meanBoff = realHdNdEpBkg->GetBinContent(0)*fObsTime*fTau;
   Float_t meanF    = GetdNdEpFrgIntegral()*fObsTime;


### PR DESCRIPTION
I have added the possibility of including a signal in the fast simulated samples for Iact1dUnbinnedLkl and Iact1dBinnedLkl classes.
I have also modified exec/jointLklDM.cc [BUT NOT THE CORRESPONDING MACRO!!!] and rcfiles/jointLkl.rc  to use this new feature.
The input parameter (set in the rc-file) is the assumed value of \<sv\>, and to convert it to the expected number of signal events and their distribution in E', the DM fUnitsOfG and dNdEpSignal histogram must have been previously defined. 
Therefore, the previous scheme in which the simulation was produced immediately after the input files were read would not work (except for \<sv\>=0), because fUnitsOfG depends also on the considered mass and annihilation/decay channel. 
Now, when \<sv\> \> 0, an independent simulation has to be produced per mass. Note that although \<sv\> is always the same, the DM particle mass changes and it's always exactly equal to the mass searched for. 
A modification is pending by which we can decouple these two things: the true DM mass used for the generation of events, and the value assumed when building the likelihood.  But this should be enough for producing the plots for replying to the referee of the all-dSph MAGIC paper
@dkerszberg: can you please make a few checks? I suggest the following:
- Simulate a signal with \<sv\> above the sensitivity in a mass range, and check that the best-fit \<sv\> and upper limits you obtain in such cases agree with the simulated value, for binned and unbinned cases
- Check the output plots for consistency with the previous point too. In particular, for sufficiently high value of simulated \<sv\> you should see the signal shape in the On event energy distribution
- For a given mass, use DlogJ = 0 and gIsPositive=FALSE to simulate the case \<sv\> = 0 and see what  is the value of the 95% CL **sensitivity** that you obtain. Then make some 300 simulations of \<sv\>=sensitivity and plot the obtained distribution of best-fit values of \<sv\>. Check that about 5% of the obtained cases are below 0.
- Once you do that you can try some typical DlogJ value and compare what happens