### PR TITLE
Update codemeta and zenodo .jsons according to latest OSSR metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -7,41 +7,58 @@
     ],
     "creators": [
         {
-            "affiliation": "IFAE",
+            "affiliation": "Institut de F\u00edsica d'Altes Energies (IFAE)",
             "name": "Rico, Javier",
             "orcid": "0000-0003-4137-1134"
         },
         {
-            "affiliation": "IFAE",
+            "affiliation": "Institut de F\u00edsica d'Altes Energies (IFAE)",
             "name": "Nigro, Cosimo",
             "orcid": "0000-0001-8375-1907"
         },
         {
-            "affiliation": "IFAE",
+            "affiliation": "Institut de F\u00edsica d'Altes Energies (IFAE)",
             "name": "Kerszberg, Daniel",
             "orcid": "0000-0002-5289-1509"
         },
         {
-            "affiliation": "UCM",
+            "affiliation": "Universidad Complutense de Madrid (UCM)",
             "name": "Miener, Tjark",
             "orcid": "0000-0003-1821-7964"
         }
     ],
-    "description": "gLike is a general-purpose ROOT-based code framework for the numerical maximization of joint likelihood functions.\n The joint likelihood function has one free parameter (named g) and as many nuisance parameters as wanted, which will be profiled in the maximization process.",
+    "description": "gLike is a general-purpose ROOT-based code framework for the numerical maximization of joint likelihood functions. The joint likelihood function has one free parameter (named g) and as many nuisance parameters as wanted, which will be profiled in the maximization process.",
     "grants": [
         {
             "id": "10.13039/501100000780::824064"
         }
     ],
     "keywords": [
-        "joint likelihood",
+        "CTA",
+        "jupyter-notebook",
+        "particle astrophysics",
+        "particle physics",
         "dark matter",
         "gamma-ray astronomy"
     ],
     "language": "eng",
     "license": "GPL-3.0",
-    "publication_date": "2022-01-21",
+    "publication_date": "2020-07-30",
+    "related_identifiers": [
+        {
+            "identifier": "https://github.com/javierrico/gLike",
+            "relation": "isDerivedFrom",
+            "resource_type": "software",
+            "scheme": "url"
+        },
+        {
+            "identifier": "https://github.com/javierrico/gLike#readme",
+            "relation": "isDocumentedBy",
+            "resource_type": "publication-softwaredocumentation",
+            "scheme": "url"
+        }
+    ],
     "title": "gLike",
     "upload_type": "software",
-    "version": "v00.10.02"
+    "version": "00.10.03"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -43,7 +43,7 @@
     ],
     "language": "eng",
     "license": "GPL-3.0",
-    "publication_date": "2020-07-30",
+    "publication_date": "2022-11-21",
     "related_identifiers": [
         {
             "identifier": "https://github.com/javierrico/gLike",

--- a/codemeta.json
+++ b/codemeta.json
@@ -5,34 +5,36 @@
     "codeRepository": "https://github.com/javierrico/gLike",
     "dateCreated": "2018-11-13",
     "datePublished": "2020-07-30",
-    "dateModified": "2021-03-12",
-    "downloadUrl": "https://github.com/javierrico/gLike/releases/tag/v00.10.00",
+    "dateModified": "2022-11-21",
+    "downloadUrl": "https://github.com/javierrico/gLike/releases/tag/v00.10.03",
     "issueTracker": "https://github.com/javierrico/gLike/issues",
     "name": "gLike",
-    "version": "v00.10.00",
+    "version": "00.10.03",
     "identifier": "10.5281/zenodo.3967385",
-    "description": "gLike is a general-purpose ROOT-based code framework for the numerical maximization of joint likelihood functions.\n The joint likelihood function has one free parameter (named g) and as many nuisance parameters as wanted, which will be profiled in the maximization process.",
-    "applicationCategory": "high-energy physics",
-    "funding": "ESCAPE EU H2020 824064",
-    "developmentStatus": "active",
+    "description": "gLike is a general-purpose ROOT-based code framework for the numerical maximization of joint likelihood functions. The joint likelihood function has one free parameter (named g) and as many nuisance parameters as wanted, which will be profiled in the maximization process.",
+    "applicationCategory": "Astrophysics",
+    "funding": "ESCAPE 824064",
+    "readme": "https://github.com/javierrico/gLike#readme",
+    "softwareVersion": "00.10.03",
     "funder": {
         "@type": "Organization",
-        "name": "IFAE"
+        "name": "European Union's Horizon 2020 research and innovation programme"
     },
     "keywords": [
-        "joint likelihood",
+        "CTA",
+        "jupyter-notebook",
+        "particle astrophysics",
+        "particle physics",
         "dark matter",
         "gamma-ray astronomy"
     ],
     "programmingLanguage": [
-        "C++"
+        "C++",
+        "ROOT"
     ],
     "operatingSystem": [
         "Linux",
-        "macOs"
-    ],
-    "softwareRequirements": [
-        "ROOT"
+        "MacOs"
     ],
     "author": [
         {
@@ -43,9 +45,11 @@
             "email": "jrico@ifae.es",
             "affiliation": {
                 "@type": "Organization",
-                "name": "IFAE"
+                "name": "Institut de Física d'Altes Energies (IFAE)"
             }
-        },
+        }
+    ],
+    "contributor": [
         {
             "@type": "Person",
             "@id": "https://orcid.org/0000-0001-8375-1907",
@@ -54,7 +58,7 @@
             "email": "cosimo.nigro@ifae.es",
             "affiliation": {
                 "@type": "Organization",
-                "name": "IFAE"
+                "name": "Institut de Física d'Altes Energies (IFAE)"
             }
         },
         {
@@ -65,7 +69,7 @@
             "email": "dkerzberg@ifae.es",
             "affiliation": {
                 "@type": "Organization",
-                "name": "IFAE"
+                "name": "Institut de Física d'Altes Energies (IFAE)"
             }
         },
         {
@@ -76,7 +80,20 @@
             "email": "tmiener@ucm.es",
             "affiliation": {
                 "@type": "Organization",
-                "name": "UCM"
+                "name": "Universidad Complutense de Madrid (UCM)"
+            }
+        }
+    ],
+    "maintainer": [
+        {
+            "@type": "Person",
+            "@id": "https://orcid.org/0000-0003-4137-1134",
+            "givenName": "Javier",
+            "familyName": "Rico",
+            "email": "jrico@ifae.es",
+            "affiliation": {
+                "@type": "Organization",
+                "name": "Institut de Física d'Altes Energies (IFAE)"
             }
         }
     ]


### PR DESCRIPTION
Hello,

this PR updates the `codemeta.json` and `.zenodo.json` according to the latest OSSR specifications.

Two minor things:

- I get this warning when I use the `eossr-codemeta2zenodo` tool to create the `.zenodo.json` from the `codemeta.json`
```
/Users/cosimo/work/eossr/eossr/metadata/zenodo.py:24: UserWarning: Version 00.10.03 does not follow the recommended format from semver.org.
  warnings.warn(f"Version {metadata['version']} does not follow the recommended format from semver.org.")

Conversion codemeta2zenodo done.
```
I think the problem is related to the double "00" in the major (leftmost) version number.

- @javierrico, the keywords `dateModified` in the codemeta and `published_date` in the .zenodo are the dates in which the latest release is made. If you do not make the release today, please change them. I titled the new release `v00.10.03`, as the latest tagged version in gitHub is `v00.10.02`.